### PR TITLE
Update the Evergage provider to make use of the new "page" syntax.

### DIFF
--- a/lib/evergage.js
+++ b/lib/evergage.js
@@ -81,9 +81,12 @@ Evergage.prototype.load = function (callback) {
  */
 
 Evergage.prototype.page = function (category, name, properties, options) {
+  each(properties, function(key, value) {
+    push('setCustomField', key, value, 'page');
+  });
+  push('namePage', name);
   window.Evergage.init(true);
 };
-
 
 /**
  * Trait aliases.

--- a/test/integrations/evergage.js
+++ b/test/integrations/evergage.js
@@ -172,13 +172,24 @@ describe('Evergage', function () {
     beforeEach(function (done) {
       evergage.once('load', function () {
         window.Evergage.init = sinon.spy();
+        window._aaq.push = sinon.spy();
         done();
       });
       evergage.initialize();
     });
 
-    it('should call pageview', function () {
+    it('should send a page view', function () {
       evergage.page();
+      assert(window._aaq.push.calledWith(['namePage', undefined]));
+      assert(window.Evergage.init.calledWith(true));
+    });
+
+    it('should send page properties', function () {
+      evergage.page('category', 'name', {
+        pageAttribute: 'pageAttributeValue'
+      });
+      assert(window._aaq.push.calledWith(['setCustomField', 'pageAttribute', 'pageAttributeValue', 'page']));
+      assert(window._aaq.push.calledWith(['namePage', 'name']));
       assert(window.Evergage.init.calledWith(true));
     });
   });


### PR DESCRIPTION
Update the Evergage provider to make use of the new "page" syntax to allow setting of the page's name and page-scoped custom fields.
