### PR TITLE
Fix the makefile's open command to work on both Linux and Mac.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
-
 test = http://localhost:4202
 component = node_modules/component/bin/component
 phantom = node_modules/.bin/mocha-phantomjs --setting web-security=false --setting local-to-remote-url-access=true
+openCommand = open
+os := $(shell uname)
+ifeq ($(os), Linux)
+	openCommand = xdg-open
+endif
+ifeq ($(os), Darwin)
+	openCommand = open
+endif
+
 
 build: node_modules components $(shell find lib)
 	@$(component) build --dev
@@ -29,6 +37,6 @@ test: build server
 
 test-browser: node_modules build server
 	@sleep 1
-	@open $(test)
+	@$(openCommand) $(test)
 
 .PHONY: clean server test test-browser


### PR DESCRIPTION
I'm unsure of just exactly the syntax you'd prefer to keep this tidy, but I've tested this to work on Mac & Linux at the very least (Debian-based linux).
