### PR TITLE
add initial ChurnBee integration

### DIFF
--- a/component.json
+++ b/component.json
@@ -58,6 +58,7 @@
     "lib/bugherd.js",
     "lib/bugsnag.js",
     "lib/chartbeat.js",
+    "lib/churnbee.js",
     "lib/clicktale.js",
     "lib/clicky.js",
     "lib/comscore.js",

--- a/lib/churnbee.js
+++ b/lib/churnbee.js
@@ -17,6 +17,7 @@ module.exports = exports = function(analytics){
 
 var ChurnBee = exports.Integration = integration('ChurnBee')
   .readyOnLoad()
+  .assumesPageView()
   .global('_cbq')
   .global('ChurnBee')
   .option('_setApiKey', '');

--- a/lib/churnbee.js
+++ b/lib/churnbee.js
@@ -1,0 +1,69 @@
+
+var integration = require('integration');
+var load = require('load-script');
+var alias = require('alias');
+
+/**
+ * Expose plugin
+ */
+
+module.exports = exports = function(analytics){
+  analytics.addIntegration(ChurnBee);
+};
+
+/**
+ * Expose `ChurnBee`
+ */
+
+var ChurnBee = exports.Integration = integration('ChurnBee')
+  .readyOnLoad()
+  .global('_cbq')
+  .global('ChurnBee')
+  .option('_setApiKey', '');
+
+/**
+ * Initialize
+ *
+ * https://churnbee.com/docs
+ *
+ * @param {Object} page
+ */
+
+ChurnBee.prototype.initialize = function(page){
+  window._cbq = window._cbq || [];
+  var key = this.options._setApiKey;
+  window._cbq.push(['_setApiKey', key]);
+  this.load();
+};
+
+/**
+ * Loaded?
+ *
+ * @return {Boolean}
+ */
+
+ChurnBee.prototype.loaded = function(){
+  return !! window.ChurnBee;
+};
+
+/**
+ * Load.
+ *
+ * @param {Function} fn
+ */
+
+ChurnBee.prototype.load = function(fn){
+  load('//api.churnbee.com/cb.js', fn);
+};
+
+/**
+ * Track `event` with `properties`
+ *
+ * @param {String} event
+ * @param {Object} properties
+ */
+
+ChurnBee.prototype.track = function(event, properties){
+  window._cbq.push([event, properties || {}]);
+};
+

--- a/test/index.html
+++ b/test/index.html
@@ -40,6 +40,7 @@
   <script src="test/integrations/bugherd.js"></script>
   <script src="test/integrations/bugsnag.js"></script>
   <script src="test/integrations/chartbeat.js"></script>
+  <script src="test/integrations/churnbee.js"></script>
   <script src="test/integrations/clicktale.js"></script>
   <script src="test/integrations/clicky.js"></script>
   <script src="test/integrations/comscore.js"></script>

--- a/test/integrations/churnbee.js
+++ b/test/integrations/churnbee.js
@@ -25,6 +25,7 @@ describe('ChurnBee', function(){
   it('should have the correct options', function(){
     test(churnbee)
     .name('ChurnBee')
+    .assumesPageView()
     .readyOnLoad()
     .global('_cbq')
     .global('ChurnBee')

--- a/test/integrations/churnbee.js
+++ b/test/integrations/churnbee.js
@@ -1,0 +1,103 @@
+
+describe('ChurnBee', function(){
+
+  var Churnbee = require('integrations/lib/churnbee');
+  var test = require('integration-tester');
+  var analytics = require('analytics');
+  var assert = require('assert');
+  var equal = require('equals');
+  var sinon = require('sinon');
+
+  var churnbee;
+  var options = {
+    _setApiKey: 'h_pEvkGaxoKEMgadS5-GlToHZJkGAXq70wlwUg87ZA0',
+  };
+
+  beforeEach(function(){
+    analytics.use(Churnbee);
+    churnbee = new Churnbee.Integration(options);
+  })
+
+  afterEach(function(){
+    churnbee.reset();
+  })
+
+  it('should have the correct options', function(){
+    test(churnbee)
+    .name('ChurnBee')
+    .readyOnLoad()
+    .global('_cbq')
+    .global('ChurnBee')
+    .option('_setApiKey', '');
+  })
+
+  describe('#initialize', function(){
+    beforeEach(function(){
+      churnbee.load = sinon.spy();
+    })
+
+    it('should create window._cbq', function(){
+      assert(!window._cbq);
+      churnbee.initialize();
+      assert(window._cbq);
+      assert(window._cbq.constructor == Array);
+    })
+
+    it('should set the api key', function(){
+      assert(!window._cbq);
+      churnbee.initialize();
+      assert('_setApiKey' == window._cbq[0][0]);
+      assert(churnbee.options._setApiKey == window._cbq[0][1]);
+    })
+
+    it('should call #load', function(){
+      churnbee.initialize();
+      assert(churnbee.load.called);
+    })
+  })
+
+  describe('#loaded', function(){
+    beforeEach(function(){
+      churnbee.initialize();
+    })
+
+    it('should test window.ChurnBee', function(){
+      assert(!window.ChurnBee);
+      assert(!churnbee.loaded());
+      window.ChurnBee = {};
+      assert(churnbee.loaded());
+    })
+  })
+
+  describe('#load', function(){
+    beforeEach(function(){
+      sinon.stub(churnbee, 'load');
+      churnbee.initialize();
+      churnbee.load.restore();
+    })
+
+    it('should load churnbee', function(done){
+      if (churnbee.loaded()) return done(new Error('#loaded before #load'));
+      churnbee.load(function(err){
+        if (err) return done(err);
+        assert(churnbee.loaded());
+        done();
+      })
+    })
+  })
+
+  describe('#track', function(){
+    beforeEach(function(){
+      churnbee.initialize();
+      sinon.stub(window._cbq, 'push');
+    })
+
+    it('should call _cbq.push', function(){
+      var props = { userId: 'baz' };
+      churnbee.track('register', props);
+      assert(window._cbq.push.calledWith(['register', props]));
+    })
+  })
+
+
+})


### PR DESCRIPTION
[ChurnBee](https://churnbee.com).

it supports only a handful of [events](https://churnbee.com/docs), the [client](https://api.churnbee.com/cb.js) basically ignores events that are not supported.

clients can send "custom" data using `.custom: { ... }`, should do something there ? i feel like we can just copy non supported properties and put them in `.custom`.

i'm 50% we need to map some properties, still investigating :)

![](https://i.cloudup.com/PEnBsGQHOD.png)
