### PR TITLE
Update GoSquared tracker to use latest tracker functions

### DIFF
--- a/lib/gosquared.js
+++ b/lib/gosquared.js
@@ -30,16 +30,20 @@ module.exports = exports = function (analytics) {
 var GoSquared = exports.Integration = integration('GoSquared')
   .assumesPageview()
   .readyOnLoad()
-  .global('GoSquared')
   .global('_gs')
-  .global('_gstc_lt')
-  .option('siteToken', '');
-
+  .option('siteToken', '')
+  .option('anonymizeIP', false)
+  .option('cookieDomain', null)
+  .option('useCookies', true)
+  .option('trackHash', false)
+  .option('trackLocal', false)
+  .option('trackParams', true);
 
 /**
  * Initialize.
  *
- * http://www.gosquared.com/support
+ * https://www.gosquared.com/developer/tracker
+ * Options: https://www.gosquared.com/developer/tracker/configuration
  *
  * @param {Object} page
  */
@@ -50,10 +54,21 @@ GoSquared.prototype.initialize = function (page) {
 
   // gosquared assumes a body in their script, so we need this wrapper
   onBody(function () {
-    window.GoSquared = {};
-    window.GoSquared.acct = options.siteToken;
-    window.GoSquared.q = [];
-    window._gstc_lt = new Date().getTime(); // time from `load`
+
+    // placeholder _gs function which is replaced after the tracker has loaded
+    var _gs = window._gs = window._gs || function() {
+     (_gs.q = _gs.q || []).push(arguments);
+    };
+
+    _gs(options.siteToken);
+
+    // options. this is rather verbose
+    _gs('set', 'anonymizeIP', options.anonymizeIP);
+    if (options.cookieDomain) _gs('set', 'cookieDomain', options.cookieDomain);
+    _gs('set', 'useCookies', options.useCookies);
+    _gs('set', 'trackHash', options.trackHash);
+    _gs('set', 'trackLocal', options.trackLocal);
+    _gs('set', 'trackParams', options.trackParams);
 
     self.identify(new Identify({
       traits: user.traits(),
@@ -65,13 +80,13 @@ GoSquared.prototype.initialize = function (page) {
 
 
 /**
- * Loaded?
+ * Loaded? (checks if the tracker version is set)
  *
  * @return {Boolean}
  */
 
 GoSquared.prototype.loaded = function () {
-  return !! window._gs;
+  return !! (window._gs && window._gs.v);
 };
 
 
@@ -89,7 +104,7 @@ GoSquared.prototype.load = function (callback) {
 /**
  * Page.
  *
- * https://www.gosquared.com/customer/portal/articles/612063-tracker-functions
+ * https://www.gosquared.com/developer/tracker/pageviews
  *
  * @param {Page} page
  */
@@ -97,14 +112,15 @@ GoSquared.prototype.load = function (callback) {
 GoSquared.prototype.page = function (page) {
   var props = page.properties();
   var name = page.fullName();
-  push('TrackView', props.path, name || props.title);
+
+  window._gs('track', props.path, name || props.title)
 };
 
 
 /**
  * Identify.
  *
- * https://www.gosquared.com/customer/portal/articles/612063-tracker-functions
+ * https://www.gosquared.com/developer/tracker/tagging
  *
  * @param {Identify} identify
  */
@@ -114,33 +130,24 @@ GoSquared.prototype.identify = function (identify) {
   var username = identify.username();
   var email = identify.email();
   var id = identify.userId();
-  var name = email || username || id;
-  if (id || username) window.GoSquared.UserName = id || username;
-  if (name) window.GoSquared.VisitorName = name;
-  window.GoSquared.Visitor = traits;
+
+  if (id) window._gs('set', 'visitorID', id);
+
+  var name = username || email || id;
+  if (name) window._gs('set', 'visitorName', name);
+
+  window._gs('set', 'visitor', traits);
 };
 
 
 /**
  * Track.
  *
- * https://www.gosquared.com/customer/portal/articles/609683-event-tracking
+ * https://www.gosquared.com/developer/tracker/events
  *
  * @param {Track} track
  */
 
 GoSquared.prototype.track = function (track) {
-  push('TrackEvent', track.event(), track.properties());
+  window._gs('event', track.event(), track.properties());
 };
-
-
-/**
- * Helper to push onto the GoSquared queue.
- *
- * @param {Mixed} args...
- */
-
-function push (args) {
-  args = [].slice.call(arguments);
-  window.GoSquared.q.push(args);
-}

--- a/lib/gosquared.js
+++ b/lib/gosquared.js
@@ -133,7 +133,7 @@ GoSquared.prototype.identify = function (identify) {
 
   if (id) window._gs('set', 'visitorID', id);
 
-  var name = username || email || id;
+  var name =  email || username || id;
   if (name) window._gs('set', 'visitorName', name);
 
   window._gs('set', 'visitor', traits);


### PR DESCRIPTION
Everything seems to work, however the tests for identify do not pass. Looks like it's because `test(gosquared`) overwrites the already loaded tracking code?? and the `_gs('get', 'blah')` functionality requires the tracker to have loaded to work.

``` js
// line 116 of test/integrations/gosquared
console.log(window._gs); // ==> fully loaded function
```

``` js
// line 129 of lib/gosquared
console.log(window._gs); // ==> placeholder function
```
