### PR TITLE
Kenshoo integration

### DIFF
--- a/component.json
+++ b/component.json
@@ -97,6 +97,7 @@
     "lib/inspectlet.js",
     "lib/intercom.js",
     "lib/keen-io.js",
+    "lib/kenshoo.js",
     "lib/kissmetrics.js",
     "lib/klaviyo.js",
     "lib/leadlander.js",

--- a/lib/kenshoo.js
+++ b/lib/kenshoo.js
@@ -1,0 +1,158 @@
+
+var integration = require('integration');
+var load = require('load-script');
+var is = require('is');
+
+/**
+ * Expose plugin.
+ */
+
+module.exports = exports = function (analytics) {
+  analytics.addIntegration(Kenshoo);
+};
+
+
+/**
+ * Expose `Kenshoo` integration.
+ */
+
+var Kenshoo = exports.Integration = integration('Kenshoo')
+  .readyOnLoad()
+  .global('k_trackevent')
+  .option('cid', '')
+  .option('subdomain', '')
+  .option('trackNamedPages', true)
+  .option('trackCategorizedPages', true);
+
+
+
+/**
+ * Initialize.
+ *
+ * See https://gist.github.com/justinboyle/7875832
+ *
+ * @param {Object} page
+ */
+
+Kenshoo.prototype.initialize = function(page) {
+  this.load();
+};
+
+
+/**
+ * Loaded? (checks if the tracking function is set)
+ *
+ * @return {Boolean}
+ */
+
+Kenshoo.prototype.loaded = function() {
+  return is.function(window.k_trackevent);
+};
+
+
+/**
+ * Load Kenshoo script.
+ *
+ * @param {Function} callback
+ */
+
+Kenshoo.prototype.load = function(callback) {
+  var url = "//" + this.options.subdomain +
+    ".xg4ken.com/media/getpx.php?cid=" + this.options.cid;
+  load(url, callback);
+};
+
+
+/**
+ * Completed order.
+ *
+ * https://github.com/jorgegorka/the_tracker/blob/master/lib/the_tracker/trackers/kenshoo.rb
+ *
+ *
+ * @param {Track} track
+ * @api private
+ */
+
+Kenshoo.prototype.completedOrder = function(track) {
+  this._track(track, {val: track.total()});
+};
+
+
+/**
+ * Page.
+ *
+ * @param {Page} page
+ */
+
+Kenshoo.prototype.page = function(page) {
+  var category = page.category();
+  var name = page.name();
+  var fullName = page.fullName();
+  var isNamed = (name && this.options.trackNamedPages);
+  var isCategorized = (category && this.options.trackCategorizedPages);
+  var track;
+
+  if (name && ! this.options.trackNamedPages) {
+    return;
+  }
+
+  if (category && ! this.options.trackCategorizedPages) {
+    return;
+  }
+
+  if (isNamed && isCategorized) {
+    track = page.track(fullName);
+  } else if (isNamed) {
+    track = page.track(name);
+  } else if (isCategorized) {
+    track = page.track(category);
+  } else {
+    track = page.track();
+  }
+
+  this._track(track);
+};
+
+
+/**
+ * Track.
+ *
+ * https://github.com/jorgegorka/the_tracker/blob/master/lib/the_tracker/trackers/kenshoo.rb
+ *
+ * @param {Track} event
+ */
+
+Kenshoo.prototype.track = function(track) {
+  this._track(track);
+};
+
+
+
+/**
+ * Track a Kenshoo event.
+ *
+ * Private method for sending an event. We use it because `completedOrder`
+ * can't call track directly (would result in an infinite loop).
+ *
+ * @param {track} event
+ * @param {options} object
+ */
+
+Kenshoo.prototype._track = function(track, options) {
+  options = options || { val: track.revenue() };
+
+  var params = [
+    "id=" + this.options.cid,
+    "type=" + track.event(),
+    "val=" + (options.val || '0.0'),
+    "orderId=" + (track.orderId() || ''),
+    "promoCode=" + (track.coupon() || ''),
+    "valueCurrency=" + (track.currency() || ''),
+
+    // Live tracking fields. Ignored for now (until we get documentation).
+    "GCID=",
+    "kw=",
+    "product="
+  ];
+  window.k_trackevent(params, this.options.subdomain);
+};

--- a/lib/slugs.json
+++ b/lib/slugs.json
@@ -35,6 +35,7 @@
   "inspectlet",
   "intercom",
   "keen-io",
+  "kenshoo",
   "kissmetrics",
   "klaviyo",
   "leadlander",

--- a/test/index.html
+++ b/test/index.html
@@ -71,6 +71,7 @@
   <script src="test/integrations/inspectlet.js"></script>
   <script src="test/integrations/intercom.js"></script>
   <script src="test/integrations/keen-io.js"></script>
+  <script src="test/integrations/kenshoo.js"></script>
   <script src="test/integrations/kissmetrics.js"></script>
   <script src="test/integrations/klaviyo.js"></script>
   <script src="test/integrations/leadlander.js"></script>

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,7 @@ describe('integrations', function () {
   var object = require('object');
 
   it('should export our integrations', function () {
-    assert(object.length(Integrations) === 70);
+    assert(object.length(Integrations) === 71);
   });
 
 });

--- a/test/integrations/kenshoo.js
+++ b/test/integrations/kenshoo.js
@@ -1,0 +1,252 @@
+describe('Kenshoo', function () {
+
+  var analytics = require('analytics');
+  var assert = require('assert');
+  var Kenshoo = require('integrations/lib/kenshoo');
+  var sinon = require('sinon');
+  var test = require('integration-tester');
+
+  var kenshoo;
+  // Settings taken from https://gist.github.com/justinboyle/7875832
+  var settings = {
+    cid: 'd590cb3f-ec81-4da7-97d6-3013ec020455',
+    subdomain: '1223'
+  };
+
+  beforeEach(function() {
+    kenshoo = new Kenshoo.Integration(settings);
+    kenshoo.initialize();
+  });
+
+  afterEach(function() {
+    kenshoo.reset();
+  });
+
+  it("should have the right settings", function() {
+    test(kenshoo)
+      .name('Kenshoo')
+      .readyOnLoad()
+      .global('k_trackevent')
+      .option('cid', '')
+      .option('subdomain', '')
+      .option('trackCategorizedPages', true)
+      .option('trackNamedPages', true);
+  });
+
+  describe("#initialize", function() {
+    beforeEach(function() {
+      sinon.spy(kenshoo, 'load');
+    });
+
+    it("should call #load", function() {
+      kenshoo.initialize();
+      assert(kenshoo.load.called);
+    });
+  });
+
+  describe("#loaded", function() {
+
+    it("should test window.k_trackevent", function() {
+      assert( ! kenshoo.loaded());
+      window.k_trackevent = {};
+      assert( ! kenshoo.loaded());
+      window.k_trackevent = function() {};
+      assert(kenshoo.loaded());
+    });
+  });
+
+  describe("#load", function() {
+    beforeEach(function () {
+      sinon.stub(kenshoo, 'load');
+      kenshoo.initialize();
+      kenshoo.load.restore();
+    });
+
+    it('should change loaded state', function (done) {
+      assert(!kenshoo.loaded());
+      kenshoo.load(function (err) {
+        if (err) return done(err);
+        assert(kenshoo.loaded());
+        done();
+      });
+    });
+  });
+
+  /**
+   * Helper fun to return Kenshoo params array.
+   */
+
+  function constructParams(params) {
+    return [
+      "id=" + settings.cid,
+      "type=" + params.type,
+      "val=" + params.val,
+      "orderId=" + params.orderId,
+      "promoCode=" + params.promoCode,
+      "valueCurrency=" + params.valueCurrency,
+
+      // Live tracking params (currently ignored).
+      "GCID=",
+      "kw=",
+      "product="
+    ];
+  }
+
+  describe("#completedOrder", function() {
+    beforeEach(function () {
+      kenshoo.initialize();
+      window.k_trackevent = sinon.stub();
+    });
+
+    it("should send the correct tracking parameters", function() {
+      test(kenshoo).track('completed order', {
+        total: "42",
+        orderId: "84",
+        coupon: "rubberduck",
+        currency: "EUR",
+      });
+
+      assert(window.k_trackevent.calledWith(
+        constructParams({
+          type: "completed order",
+          val: "42",
+          orderId: "84",
+          promoCode: "rubberduck",
+          valueCurrency: "EUR"
+        }), settings.subdomain));
+    });
+
+    it("should track `total` and not `revenue` as `val`", function() {
+      test(kenshoo).track('completed order', {
+        revenue: "1",
+        orderId: "84",
+        coupon: "rubberduck",
+        currency: "EUR",
+      });
+
+      assert(window.k_trackevent.calledWith(
+        constructParams({
+          type: "completed order",
+          val: "0.0", // default val
+          orderId: "84",
+          promoCode: "rubberduck",
+          valueCurrency: "EUR"
+        }), settings.subdomain));
+    });
+  });
+
+  describe('#page', function () {
+    beforeEach(function () {
+      kenshoo.initialize();
+      window.k_trackevent = sinon.stub();
+    });
+
+    it('should track an unnamed, uncategorized page view', function () {
+      test(kenshoo).page();
+      kenshoo.options.trackNamedPages = false;
+      test(kenshoo).page();
+      kenshoo.options.trackCategorizedPages = false;
+      test(kenshoo).page();
+
+      assert(window.k_trackevent.alwaysCalledWith(
+        constructParams({
+          type: "Loaded a Page",
+          val: "0.0",
+          orderId: "",
+          promoCode: "",
+          valueCurrency: "USD"
+        }), settings.subdomain));
+      assert(window.k_trackevent.calledThrice);
+    });
+
+
+    it('should track a named page', function () {
+      test(kenshoo).page(null, 'testName');
+       assert(window.k_trackevent.calledWith(
+        constructParams({
+          type: "Viewed testName Page",
+          val: "0.0",
+          orderId: "",
+          promoCode: "",
+          valueCurrency: "USD"
+        }), settings.subdomain));
+    });
+
+    it('should track a name + category page', function () {
+      test(kenshoo).page('testCategory', 'testName');
+       assert(window.k_trackevent.calledWith(
+        constructParams({
+          type: "Viewed testCategory testName Page",
+          val: "0.0",
+          orderId: "",
+          promoCode: "",
+          valueCurrency: "USD"
+        }), settings.subdomain));
+    });
+
+    it('should track a categorized page', function () {
+      test(kenshoo).page('testCategory');
+      assert(window.k_trackevent.calledWith(
+        constructParams({
+          type: "Viewed testCategory Page",
+          val: "0.0",
+          orderId: "",
+          promoCode: "",
+          valueCurrency: "USD"
+        }), settings.subdomain));
+    });
+
+    it('should not track a named or categorized page when the option is off', function () {
+      kenshoo.options.trackNamedPages = false;
+      kenshoo.options.trackCategorizedPages = false;
+      test(kenshoo).page(null, 'Name');
+      test(kenshoo).page('Category', 'Name');
+      assert(window.k_trackevent.notCalled);
+    });
+  });
+
+  describe("#track", function() {
+    beforeEach(function () {
+      kenshoo.initialize();
+      window.k_trackevent = sinon.stub();
+    });
+
+    it('should track an event', function () {
+      test(kenshoo).track('event');
+      var params = constructParams({
+         type: "event",
+         val: "0.0",
+         orderId: "",
+         promoCode: "",
+         valueCurrency: "USD"
+      });
+      assert(window.k_trackevent.calledWith(params, settings.subdomain));
+    });
+
+    it('should track revenue as `val`', function () {
+      test(kenshoo).track('event', {revenue: "10.2"});
+      var params = constructParams({
+         type: "event",
+         val: "10.2",
+         orderId: "",
+         promoCode: "",
+         valueCurrency: "USD"
+      });
+      assert(window.k_trackevent.calledWith(params, settings.subdomain));
+    });
+
+    it("should default `val` to 0.0 if no 'revenue' is set", function() {
+      test(kenshoo).track('completed order', {
+      });
+
+      assert(window.k_trackevent.calledWith(
+        constructParams({
+          type: "completed order",
+          val: "0.0",
+          orderId: "",
+          promoCode: "",
+          valueCurrency: "USD"
+        }), settings.subdomain));
+    });
+  });
+});


### PR DESCRIPTION
I've implemented the `completedOrder` handler. The other events are still a bit unclear (see comments in #76).

Also, the "Live tracking" fields will probably require access to documentation (`kw`, `GCID` and `product` no idea what to send there - maybe just `track.proxy('properties.kw') || ''` etc would do?); all the examples I've found leave them empty but I haven't found any that would actually fire a `completed order` event.
