### PR TITLE
updating tests for new _fp mapping

### DIFF
--- a/lib/quantcast.js
+++ b/lib/quantcast.js
@@ -94,7 +94,7 @@ Quantcast.prototype.page = function (page) {
   var name = page.name();
   var settings = {
     event: 'refresh',
-    labels: label('Page', category, name),
+    labels: labels('Page', category, name),
     qacct: this.options.pCode,
   };
   if (user.id()) settings.uid = user.id();
@@ -130,7 +130,7 @@ Quantcast.prototype.track = function (track) {
   var revenue = track.revenue();
   var settings = {
     event: 'click',
-    labels: label('Event', name),
+    labels: labels('Event', name),
     qacct: this.options.pCode
   };
   if (revenue !== null) settings.revenue = (revenue+''); // convert to string
@@ -151,7 +151,7 @@ Quantcast.prototype.completedOrder = function(track){
   var revenue = track.total();
   var settings = {
     event: 'refresh', // the example Quantcast sent has completed order send refresh not click
-    labels: label('Event', name),
+    labels: labels('Event', name),
     revenue: (revenue+''), // convert to string
     orderid: track.orderId(),
     qacct: this.options.pCode
@@ -167,15 +167,16 @@ Quantcast.prototype.completedOrder = function(track){
  * ....
  */
 
-function label() {
+function labels() {
   var args = [];
   for (var i = 0; i < arguments.length; i++) {
     args.push(arguments[i]);
   }
   if (args.length === 0) return '';
-  return args.filter(function(arg) {
+  var basic = args.filter(function(arg) {
     return arg;
   }).map(function(arg) {
     return arg.replace(/,/g, ';');
   }).join('.');
+  return [basic, ['_fp', basic].join('.')].join(',');
 }

--- a/test/integrations/quantcast.js
+++ b/test/integrations/quantcast.js
@@ -98,25 +98,21 @@ describe('Quantcast', function () {
     });
 
     it('should push the page name as a label', function () {
-      var name = 'Page Name';
-      test(quantcast).page(name);
+      test(quantcast).page('Page Name');
       var item = window._qevents[1];
-      assert(item.labels === 'Page.'+name);
+      assert(item.labels === 'Page.Page Name,_fp.Page.Page Name');
     });
 
     it('should push the page name as a label without commas', function () {
-      var name = 'Page, Name';
-      test(quantcast).page(name);
+      test(quantcast).page('Page, Name');
       var item = window._qevents[1];
-      assert(item.labels === 'Page.Page; Name');
+      assert(item.labels === 'Page.Page; Name,_fp.Page.Page; Name');
     });
 
     it('should push the page category and name as labels', function () {
-      var category = 'Category Name';
-      var name = 'Page Name';
-      test(quantcast).page(category, name);
+      test(quantcast).page('Category', 'Page');
       var item = window._qevents[1];
-      assert(item.labels === ('Page.'+category+'.'+name));
+      assert(item.labels === ('Page.Category.Page,_fp.Page.Category.Page'));
     });
 
     it('should push the user id', function () {
@@ -152,7 +148,7 @@ describe('Quantcast', function () {
     it('should push a label for the event', function () {
       test(quantcast).track('event');
       var item = window._qevents[1];
-      assert(item.labels === 'Event.event');
+      assert(item.labels === 'Event.event,_fp.Event.event');
     });
 
     it('should push revenue for the event', function () {
@@ -196,7 +192,7 @@ describe('Quantcast', function () {
       var item = window._qevents[1];
       assert(item.orderid === '780bc55');
       assert(item.revenue === '99.99');
-      assert(item.labels === 'Event.completed order');
+      assert(item.labels === 'Event.completed order,_fp.Event.completed order');
     });
   });
 


### PR DESCRIPTION
@yields had to had `_fp` prefixes as well for the ad part of the integration not just audiences
