### PR TITLE
Adds support for Piwik

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,6 +55,7 @@ If you ever need any help, feel free to email [friends@segment.io](mailto:friend
 - [Optimizely](https://www.optimizely.com/)
 - [Perfect Audience](https://www.perfectaudience.com/)
 - [Pingdom](https://www.pingdom.com/)
+- [Piwik](https://www.piwik.org)
 - [Preact](http://www.preact.io/)
 - [Qualaroo](https://qualaroo.com/)
 - [Quantcast](https://www.quantcast.com/)

--- a/component.json
+++ b/component.json
@@ -113,6 +113,7 @@
     "lib/optimizely.js",
     "lib/perfect-audience.js",
     "lib/pingdom.js",
+    "lib/piwik.js",
     "lib/preact.js",
     "lib/qualaroo.js",
     "lib/quantcast.js",

--- a/lib/piwik.js
+++ b/lib/piwik.js
@@ -31,8 +31,7 @@ Piwik.prototype.initialize = function () {
   window._paq = window._paq || [];
   push('setSiteId', this.options.id);
 
-  push('setTrackerUrl', this.options.url + '/piwik.php'); 
-  push('trackPageView'); 
+  push('setTrackerUrl', this.options.url + '/piwik.php');
   push('enableLinkTracking');
 
   this.load();

--- a/lib/piwik.js
+++ b/lib/piwik.js
@@ -18,7 +18,7 @@ var Piwik = exports.Integration = integration('Piwik')
   .option('url', null)
   .option('id', '')
   .assumesPageview()
-  .readyOnLoad();
+  .readyOnInitialize();
 
 /**
  * Initialize.

--- a/lib/piwik.js
+++ b/lib/piwik.js
@@ -1,0 +1,65 @@
+var integration = require('integration'),
+    load = require('load-script'),
+    push = require('global-queue')('_paq');
+
+/**
+ * Expose plugin
+ */
+module.exports = exports = function (analytics) {
+  analytics.addIntegration(Piwik);
+};
+
+/**
+ * Expose `Piwik` integration.
+ */
+
+var Piwik = exports.Integration = integration('Piwik')
+  .global('_paq')
+  .option('url', null)
+  .option('id', '')
+  .assumesPageview()
+  .readyOnLoad();
+
+/**
+ * Initialize.
+ *
+ * http://piwik.org/docs/javascript-tracking/#toc-asynchronous-tracking
+ */
+
+Piwik.prototype.initialize = function () {
+
+  window._paq = window._paq || [];
+  push('setSiteId', this.options.id);
+
+  push('setTrackerUrl', this.options.url + '/piwik.php'); 
+  push('trackPageView'); 
+  push('enableLinkTracking');
+
+  this.load();
+};
+
+/**
+ * Load the Piwik Analytics library.
+ */
+
+Piwik.prototype.load = function (callback) {
+  load(this.options.url + "/piwik.js", callback);
+};
+
+/**
+ * Check if Piwik is loaded
+ */
+
+Piwik.prototype.loaded = function () {
+  return !! (window._paq && window._paq.push !== Array.prototype.push);
+};
+
+/**
+ * Page
+ *
+ * @param {Page} page
+ */
+
+Piwik.prototype.page = function (page) {
+  push('trackPageView');
+};

--- a/lib/slugs.json
+++ b/lib/slugs.json
@@ -51,6 +51,7 @@
   "optimizely",
   "perfect-audience",
   "pingdom",
+  "piwik",
   "preact",
   "qualaroo",
   "quantcast",

--- a/test/index.html
+++ b/test/index.html
@@ -87,6 +87,7 @@
   <script src="test/integrations/optimizely.js"></script>
   <script src="test/integrations/perfect-audience.js"></script>
   <script src="test/integrations/pingdom.js"></script>
+  <script src="test/integrations/piwik.js"></script>
   <script src="test/integrations/preact.js"></script>
   <script src="test/integrations/qualaroo.js"></script>
   <script src="test/integrations/quantcast.js"></script>

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,3 @@
-
 describe('integrations', function () {
 
   var assert = require('assert');
@@ -6,7 +5,7 @@ describe('integrations', function () {
   var object = require('object');
 
   it('should export our integrations', function () {
-    assert(object.length(Integrations) === 71);
+    assert(object.length(Integrations) === 72);
   });
 
 });

--- a/test/integrations/piwik.js
+++ b/test/integrations/piwik.js
@@ -30,7 +30,7 @@ describe('Piwik', function () {
       .option('id', '')
       .option('url', null)
       .assumesPageview()
-      .readyOnLoad();
+      .readyOnInitialize();
   });
 
   describe('#initialize', function () {

--- a/test/integrations/piwik.js
+++ b/test/integrations/piwik.js
@@ -1,0 +1,83 @@
+describe('Piwik', function () {
+
+  var Piwik     = require('integrations/lib/piwik'),
+      analytics = require('analytics'),
+      assert    = require('assert'),
+      equal     = require('equals'),
+      sinon     = require('sinon'),
+      each      = require('each'),
+      test      = require('integration-tester'),
+      piwik,
+      settings  = {
+        id: 42,
+        url: 'https://demo.piwik.org'
+      };
+
+  beforeEach(function () {
+    analytics.use(Piwik);
+    piwik = new Piwik.Integration(settings);
+    piwik.initialize(); // noop
+  });
+
+  afterEach(function () {
+    piwik.reset();
+  });
+
+  it('should have the right settings', function () {
+    test(piwik)
+      .name('Piwik')
+      .global('_paq')
+      .option('id', '')
+      .option('url', null)
+      .assumesPageview()
+      .readyOnLoad();
+  });
+
+  describe('#initialize', function () {
+    beforeEach(function () {
+      piwik.load = sinon.spy();
+    });
+
+    it('should call #load', function () {
+      piwik.initialize();
+      assert(piwik.load.called);
+    });
+
+    it('should push the id onto window._paq', function () {
+      piwik.initialize();
+      assert(equal(window._paq[0], ['setSiteId', settings.id]));
+    });
+
+    it('should push the url onto window._paq', function () {
+      piwik.initialize();
+      assert(equal(window._paq[1], ['setTrackerUrl', settings.url + "/piwik.php"]));
+    });
+  });
+
+  describe('#load', function () {
+    beforeEach(function () {
+      sinon.stub(piwik, 'load');
+      piwik.initialize();
+      piwik.load.restore();
+    });
+
+    it('should change loaded state', function (done) {
+      assert(!piwik.loaded());
+      piwik.load(function (err) {
+        if (err) return done(err);
+        assert(piwik.loaded());
+        done();
+      });
+    });
+  });
+
+  describe('#page', function() {
+    beforeEach(function () {
+      piwik.initialize();
+    });
+
+    it('should send a page view', function () {
+      test(piwik).page();
+    });
+  });
+});


### PR DESCRIPTION
Adds support for [Piwik](http://piwik.org/), supersedes [GH #119](https://github.com/segmentio/analytics.js/pull/193), and resolves concerns brought up in [GH #19](https://github.com/segmentio/analytics.js/pull/19)

Piwik's Press Pack can be downloaded from http://piwik.org/piwik_press_pack.zip, which contains the vector image that should be used.

Thanks to @mattab for providing a permanent place to run the tests against.

@ianstormtaylor @noinput @halfdan @patcon @sethers @vanthome
