### PR TITLE
add adroll events, closes #27 ?

### DIFF
--- a/lib/adroll.js
+++ b/lib/adroll.js
@@ -10,6 +10,11 @@ var load = require('load-script');
 
 var user;
 
+/**
+ * HOP
+ */
+
+var has = Object.prototype.hasOwnProperty;
 
 /**
  * Expose plugin.
@@ -32,6 +37,7 @@ var AdRoll = exports.Integration = integration('AdRoll')
   .global('adroll_adv_id')
   .global('adroll_pix_id')
   .global('adroll_custom_data')
+  .option('events', {})
   .option('advId', '')
   .option('pixId', '');
 
@@ -76,4 +82,22 @@ AdRoll.prototype.load = function (callback) {
     http: 'http://a.adroll.com/j/roundtrip.js',
     https: 'https://s.adroll.com/j/roundtrip.js'
   }, callback);
+};
+
+/**
+ * Track.
+ * 
+ * @param {Track} track
+ */
+
+AdRoll.prototype.track = function(track){
+  var events = this.options.events;
+  var total = track.revenue() || track.total();
+  var event = track.event();
+  if (has.call(events, event)) event = events[event];
+  window.__adroll.record_user({
+    adroll_conversion_value_in_dollars: total || 0,
+    order_id: track.orderId() || 0,
+    adroll_segments: event
+  });
 };

--- a/test/integrations/adroll.js
+++ b/test/integrations/adroll.js
@@ -97,4 +97,47 @@ describe('AdRoll', function () {
     });
   });
 
+  describe('#track', function(){
+    beforeEach(function(){
+      window.__adroll.record_user = sinon.spy();
+    })
+
+    it('should send events', function(){
+      test(adroll).track('event', {});
+      assert(window.__adroll.record_user.calledWith({
+        adroll_segments: 'event',
+        adroll_conversion_value_in_dollars: 0,
+        order_id: 0
+      }));
+    })
+
+    it('should track Completed Order', function(){
+      test(adroll).track('Completed Order', { total: 1.99, orderId: 1 });
+      assert(window.__adroll.record_user.calledWith({
+        adroll_segments: 'Completed Order',
+        adroll_conversion_value_in_dollars: 1.99,
+        order_id: 1
+      }));
+    })
+
+    it('should pass .revenue as conversion value', function(){
+      test(adroll).track('purchase', { revenue: 2.99 });
+      assert(window.__adroll.record_user.calledWith({
+        adroll_segments: 'purchase',
+        adroll_conversion_value_in_dollars: 2.99,
+        order_id: 0
+      }));
+    })
+
+    it('should respect .events option', function(){
+      adroll.options.events = { event: 'segment' };
+      test(adroll).track('event', { revenue: 3.99 });
+      assert(window.__adroll.record_user.calledWith({
+        adroll_segments: 'segment',
+        adroll_conversion_value_in_dollars: 3.99,
+        order_id: 0
+      }));
+    })
+  })
+
 });


### PR DESCRIPTION
needs adroll dashboard testing still. ref: http://support.adroll.com/segmenting-clicks/

@reinpk @DirtyAnalytics i saw that `.record_user()` accepts `adroll_conversion_value_in_dollars` and `order_id`. i think this closes #27 ?
