### PR TITLE
Add option for custom/extra params in GA create

### DIFF
--- a/lib/google-analytics.js
+++ b/lib/google-analytics.js
@@ -94,7 +94,7 @@ GA.prototype.initialize = function () {
       params[option] = opts.params[option];
     }
   }
-  window.ga('create', opts.trackingId, 'auto', params);
+  window.ga('create', opts.trackingId, params);
 
   // display advertising
   if (opts.doubleClick) {

--- a/lib/google-analytics.js
+++ b/lib/google-analytics.js
@@ -189,7 +189,7 @@ GA.prototype.track = function (track, options) {
 
   window.ga('send', 'event', {
     eventAction: event,
-    eventCategory: this._category || props.category || 'All',
+    eventCategory: props.category || this._category || 'All',
     eventLabel: props.label,
     eventValue: formatValue(props.value || revenue),
     nonInteraction: props.noninteraction || opts.noninteraction

--- a/lib/google-analytics.js
+++ b/lib/google-analytics.js
@@ -1,4 +1,3 @@
-
 var callback = require('callback');
 var canonical = require('canonical');
 var each = require('each');
@@ -82,11 +81,20 @@ GA.prototype.initialize = function () {
   };
   window.ga.l = new Date().getTime();
 
-  window.ga('create', opts.trackingId, {
+  // set default params
+  var params = {
     cookieDomain: opts.domain || GA.prototype.defaults.domain, // to protect against empty string
     siteSpeedSampleRate: opts.siteSpeedSampleRate,
-    allowLinker: true
-  });
+    allowLinker: true,
+  };
+
+  // add extra params
+  if (opts.params) {
+    for (var option in opts.params) {
+      params[option] = opts.params[option];
+    }
+  }
+  window.ga('create', opts.trackingId, 'auto', params);
 
   // display advertising
   if (opts.doubleClick) {


### PR DESCRIPTION
There is a need for more customization of the GA create call - for myself it's passing an existing clientId to deal with cross domains for example. Mods allow a "params" field to be added to initialization.

```
analytics.initialize({
  'Google Analytics': {
    trackingId: 'UA-XXXXXX-0',
    universalClient: true,
    params: {
      clientId: '111',
      storage: 'none'
    }
  }
});
```
