### PR TITLE
livechat: make sure LC_API & LC_Invite are loaded

### DIFF
--- a/lib/livechat.js
+++ b/lib/livechat.js
@@ -3,6 +3,7 @@ var each = require('each');
 var integration = require('integration');
 var load = require('load-script');
 var clone = require('clone');
+var when = require('when');
 
 
 /**
@@ -22,6 +23,9 @@ var LiveChat = exports.Integration = integration('LiveChat')
   .assumesPageview()
   .readyOnLoad()
   .global('__lc')
+  .global('__lc_inited')
+  .global('LC_API')
+  .global('LC_Invite')
   .option('group', 0)
   .option('license', '');
 
@@ -36,7 +40,6 @@ var LiveChat = exports.Integration = integration('LiveChat')
 
 LiveChat.prototype.initialize = function (page) {
   window.__lc = clone(this.options);
-  this.isLoaded = false;
   this.load();
 };
 
@@ -48,7 +51,7 @@ LiveChat.prototype.initialize = function (page) {
  */
 
 LiveChat.prototype.loaded = function () {
-  return this.isLoaded;
+  return !!(window.LC_API && window.LC_Invite);
 };
 
 
@@ -62,8 +65,9 @@ LiveChat.prototype.load = function (callback) {
   var self = this;
   load('//cdn.livechatinc.com/tracking.js', function(err){
     if (err) return callback(err);
-    self.isLoaded = true;
-    callback();
+    when(function(){
+      return self.loaded();
+    }, callback);
   });
 };
 

--- a/test/integrations/livechat.js
+++ b/test/integrations/livechat.js
@@ -12,7 +12,7 @@ describe('LiveChat', function () {
 
   var livechat;
   var settings = {
-    license: '1520'
+    license: '4293371'
   };
 
   beforeEach(function () {
@@ -33,6 +33,9 @@ describe('LiveChat', function () {
       .assumesPageview()
       .readyOnLoad()
       .global('__lc')
+      .global('LC_API')
+      .global('LC_Invite')
+      .global('__lc_inited')
       .option('license', '');
   });
 
@@ -56,7 +59,9 @@ describe('LiveChat', function () {
   describe('#loaded', function () {
     it('should test .isLoaded', function () {
       assert(!livechat.loaded());
-      livechat.isLoaded = true;
+      window.LC_API = {};
+      assert(!livechat.loaded());
+      window.LC_Invite = {};
       assert(livechat.loaded());
     });
   });
@@ -81,8 +86,9 @@ describe('LiveChat', function () {
   describe('#identify', function () {
     beforeEach(function (done) {
       livechat.initialize();
-      livechat.once('load', function () {
-        window.LC_API.set_custom_variables = sinon.spy();
+      livechat.once('ready', function () {
+        sinon.spy(window.LC_API, 'set_custom_variables');
+        window.LC_API.set_custom_variables.reset();
         done();
       });
     });
@@ -98,22 +104,18 @@ describe('LiveChat', function () {
     it('should send traits', function () {
       test(livechat).identify(null, { trait: true });
       assert(window.LC_API.set_custom_variables.calledWith([
-        { name: 'trait', value: true }
+        { name: 'trait', value: 'true' }
       ]));
     });
 
     it('should send an id and traits', function () {
       test(livechat).identify('id', { trait: true });
       assert(window.LC_API.set_custom_variables.calledWith([
-        { name: 'trait', value: true },
+        { name: 'trait', value: 'true' },
         { name: 'id', value: 'id' },
         { name: 'User ID',value: 'id' }
       ]));
     });
   });
-
-  after(function(){
-    livechat.initialize();
-  })
 
 });


### PR DESCRIPTION
this makes sure that `.LC_API` and `.LC_Invite` are ready before `.identify()` is ever called or the integration emits `ready`.

cc @ianstormtaylor 
