### PR TITLE
Add social integration options to GA track

### DIFF
--- a/lib/google-analytics.js
+++ b/lib/google-analytics.js
@@ -169,6 +169,7 @@ GA.prototype.page = function (page) {
  *
  * https://developers.google.com/analytics/devguides/collection/analyticsjs/events
  * https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference
+ * https://developers.google.com/analytics/devguides/collection/analyticsjs/social-interactions
  *
  * @param {Track} event
  */
@@ -179,14 +180,23 @@ GA.prototype.track = function (track, options) {
   var revenue = track.revenue();
   var event = track.event();
 
-  window.ga('send', 'event', {
-    eventAction: event,
-    eventCategory: this._category || props.category || 'All',
-    eventLabel: props.label,
-    eventValue: formatValue(props.value || revenue),
-    nonInteraction: props.noninteraction || opts.noninteraction
-  });
+  if (event === 'social') {
+    window.ga('send', 'social', {
+      socialNetwork: opts.socialNetwork,
+      socialAction:  opts.socialAction,
+      socialTarget:  opts.socialTarget
+    });
+  } else {
+    window.ga('send', 'event', {
+      eventAction: event,
+      eventCategory: this._category || props.category || 'All',
+      eventLabel: props.label,
+      eventValue: formatValue(props.value || revenue),
+      nonInteraction: props.noninteraction || opts.noninteraction
+    });
+  }
 };
+
 
 /**
  * Completed order.

--- a/test/integrations/google-analytics.js
+++ b/test/integrations/google-analytics.js
@@ -309,6 +309,19 @@ describe('Google Analytics', function () {
           nonInteraction: true
         }));
       });
+
+      it('should send social options', function () {
+        test(ga).track('social', {}, { 'Google Analytics': {
+            socialNetwork: 'facebook',
+            socialAction: 'like',
+            socialTarget: '/path'
+        }});
+        assert(window.ga.calledWith('send', 'social', {
+          socialNetwork: 'facebook',
+          socialAction: 'like',
+          socialTarget: '/path'
+        }));
+      });
     });
 
     describe('ecommerce', function(){


### PR DESCRIPTION
I need to use [GA's social interactions](https://developers.google.com/analytics/devguides/collection/analyticsjs/social-interactions), but `analytics.track(...)` doesn't appear to support that event type just yet. For now, I'm still calling it like `ga('send', 'social', ...)`.

Could something like this be added, or is there an existing method I'm missing?
