### PR TITLE
Feature/vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 components
 build
 test/pid.txt
+.vagrant

--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,20 @@ server: build kill
 	@tests=$(tests) node test/server &
 	@sleep 1
 
+server-sync: build kill
+	@tests=$(tests) node test/server
+
 test: build server test-node
 	@$(PHANTOM) $(TEST)
 
 test-node-vagrant:
 	vagrant up
 	vagrant ssh -c "cd /vagrant && make test"
+	vagrant halt
+
+test-browser-vagrant:
+	vagrant up
+	vagrant ssh -c "cd /vagrant && make build && echo \"Running server on 10.0.33.34:4202\" && make server-sync"
 	vagrant halt
 
 test-node: node_modules

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test-node-vagrant:
 
 test-browser-vagrant:
 	vagrant up
-	vagrant ssh -c "cd /vagrant && make build && echo \"Running server on 10.0.33.34:4202\" && make server-sync"
+	vagrant ssh -c "cd /vagrant && make build && printf \"\e[1;34mRunning server on 10.0.33.34:4202\n\e[0m\" && make server-sync"
 	vagrant halt
 
 test-node: node_modules

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,11 @@ server: build kill
 test: build server test-node
 	@$(PHANTOM) $(TEST)
 
+test-node-vagrant:
+	vagrant up
+	vagrant ssh -c "cd /vagrant && make test"
+	vagrant halt
+
 test-node: node_modules
 	@node_modules/.bin/mocha -R spec test/node.js
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,11 @@
+Vagrant.configure("2") do |config|
+    config.vm.box = "precise64"
+    config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+    config.vm.provision :shell, :path => "vagrant-install.sh"
+    config.vm.network :private_network, ip: '10.0.33.34'
+
+    config.vm.provider :virtualbox do |vb|
+        vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
+        vb.customize ["modifyvm", :id, "--memory", "512"]
+    end
+end

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "mocha": "~1.18.2"
   },
   "scripts": {
-    "test": "make test"
+    "test": "make test",
+    "test-vagrant": "make test-node-vagrant"
   }
 }

--- a/vagrant-install.sh
+++ b/vagrant-install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Get root up in here
+sudo su
+# Update and begin installing some utility tools
+apt-get -y update
+apt-get install -y python-software-properties git curl wget build-essential
+
+# Add nodejs repo
+add-apt-repository -y ppa:chris-lea/node.js
+apt-get -y update
+
+# Install nodejs
+apt-get install -y nodejs
+
+cd /usr/local/share/
+
+wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-linux-x86_64.tar.bz2
+tar xjf phantomjs-1.9.7-linux-x86_64.tar.bz2
+sudo ln -s /usr/local/share/phantomjs-1.9.7-linux-x86_64/bin/phantomjs /usr/local/share/phantomjs
+sudo ln -s /usr/local/share/phantomjs-1.9.7-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
+sudo ln -s /usr/local/share/phantomjs-1.9.7-linux-x86_64/bin/phantomjs /usr/bin/phantomjs

--- a/vagrant-install.sh
+++ b/vagrant-install.sh
@@ -4,7 +4,7 @@
 sudo su
 # Update and begin installing some utility tools
 apt-get -y update
-apt-get install -y python-software-properties git curl wget build-essential
+apt-get install -y python-software-properties git curl wget build-essential fontconfig
 
 # Add nodejs repo
 add-apt-repository -y ppa:chris-lea/node.js


### PR DESCRIPTION
Added vagrant support for tests in test-node.
To run tests, do `make test-node-vagrant` or `make test-browser-vagrant`
Currently it is not default test env, but its easy to make it to be so.
