### PR TITLE
Fix/kissmetrics props

### DIFF
--- a/lib/kissmetrics.js
+++ b/lib/kissmetrics.js
@@ -29,8 +29,8 @@ var KISSmetrics = exports.Integration = integration('KISSmetrics')
   .global('KM')
   .global('_kmil')
   .option('apiKey', '')
-  .option('trackNamedPages', true)
-  .option('trackCategorizedPages', true);
+  .option('trackPages', true)
+  .option('prefixEventProperties', true);
 
 
 /**
@@ -87,17 +87,16 @@ KISSmetrics.prototype.load = function (callback) {
 
 KISSmetrics.prototype.page = function (page) {
   var category = page.category();
-  var name = page.fullName();
   var opts = this.options;
 
   // named pages
-  if (name && opts.trackNamedPages) {
-    this.track(page.track(name));
-  }
-
-  // categorized pages
-  if (category && opts.trackCategorizedPages) {
-    this.track(page.track(category));
+  if (category && opts.trackPages) {
+    var track = page.track(category);
+    var props = track.properties();
+    props.Title = document.title;
+    props.Path = window.location.pathname;
+    if (this.options.prefixEventProperties) props = prefix(track.event(), props);
+    push('record', track.event(), props);
   }
 };
 
@@ -124,6 +123,7 @@ KISSmetrics.prototype.identify = function (identify) {
 
 KISSmetrics.prototype.track = function (track) {
   var props = track.properties({ revenue: 'Billing Amount' });
+  if (this.options.prefixEventProperties) props = prefix(track.event(), props);
   push('record', track.event(), props);
 };
 
@@ -203,7 +203,8 @@ KISSmetrics.prototype.completedOrder = function(track){
 function prefix(event, properties){
   var props = {};
   each(properties, function(key, val){
-    props[event + ' - ' + key] = val;
+    if (key !== 'Billing Amount')
+      props[event + ' - ' + key] = val;
   });
   return props;
 }

--- a/lib/kissmetrics.js
+++ b/lib/kissmetrics.js
@@ -95,6 +95,7 @@ KISSmetrics.prototype.page = function (page) {
     var props = track.properties();
     props.Title = document.title;
     props.Path = window.location.pathname;
+    props.URL = window.location.href;
     if (this.options.prefixEventProperties) props = prefix(track.event(), props);
     push('record', track.event(), props);
   }

--- a/lib/kissmetrics.js
+++ b/lib/kissmetrics.js
@@ -86,17 +86,18 @@ KISSmetrics.prototype.load = function (callback) {
  */
 
 KISSmetrics.prototype.page = function (page) {
-  var category = page.category();
+  var name = page.category() || page.name();
   var opts = this.options;
 
   // named pages
-  if (category && opts.trackPages) {
-    var track = page.track(category);
+  if (name && opts.trackPages) {
+    var track = page.track(name);
     var props = track.properties();
     props.Title = document.title;
     props.Path = window.location.pathname;
     props.URL = window.location.href;
-    if (this.options.prefixEventProperties) props = prefix(track.event(), props);
+    delete props.category;
+    if (this.options.prefixEventProperties) props = prefix(name, props);
     push('record', track.event(), props);
   }
 };
@@ -204,7 +205,9 @@ KISSmetrics.prototype.completedOrder = function(track){
 function prefix(event, properties){
   var props = {};
   each(properties, function(key, val){
-    if (key !== 'Billing Amount')
+    if (key === 'Billing Amount')
+      props[key] = val;
+    else
       props[event + ' - ' + key] = val;
   });
   return props;

--- a/lib/kissmetrics.js
+++ b/lib/kissmetrics.js
@@ -146,9 +146,8 @@ KISSmetrics.prototype.alias = function (alias) {
  */
 
 KISSmetrics.prototype.viewedProduct = function(track){
-  var event = 'Product Viewed';
-  var props = prefix(event, toProduct(track));
-  push('record', event, props);
+  var props = prefix(track.event(), toProduct(track));
+  push('record', track.event(), props);
 };
 
 /**
@@ -159,9 +158,8 @@ KISSmetrics.prototype.viewedProduct = function(track){
  */
 
 KISSmetrics.prototype.addedProduct = function(track){
-  var event = 'Product Added';
-  var props = prefix(event, toProduct(track));
-  push('record', event, props);
+  var props = prefix(track.event(), toProduct(track));
+  push('record', track.event(), props);
 };
 
 /**
@@ -185,8 +183,8 @@ KISSmetrics.prototype.completedOrder = function(track){
   window._kmq.push(function(){
     var km = window.KM;
     each(products, function(product, i){
-      var track = new Track({ properties: product });
-      var item = prefix('Completed Order', toProduct(track));
+      var temp = new Track({ properties: product });
+      var item = prefix(track.event(), toProduct(temp));
       item._t = km.ts() + i;
       item._d = 1;
       km.set(item);

--- a/lib/kissmetrics.js
+++ b/lib/kissmetrics.js
@@ -146,7 +146,9 @@ KISSmetrics.prototype.alias = function (alias) {
  */
 
 KISSmetrics.prototype.viewedProduct = function(track){
-  record('Product Viewed', toProduct(track));
+  var event = 'Product Viewed';
+  var props = prefix(event, toProduct(track));
+  push('record', event, props);
 };
 
 /**
@@ -157,7 +159,9 @@ KISSmetrics.prototype.viewedProduct = function(track){
  */
 
 KISSmetrics.prototype.addedProduct = function(track){
-  record('Product Added', toProduct(track));
+  var event = 'Product Added';
+  var props = prefix(event, toProduct(track));
+  push('record', event, props);
 };
 
 /**
@@ -171,24 +175,18 @@ KISSmetrics.prototype.completedOrder = function(track){
   var products = track.products();
 
   // transaction
-  push('record', 'Purchased', {
-    'Order ID': track.orderId(),
-    'Order Subtotal': track.subtotal(),
-    'Order Total': track.total()
-  });
+  push('record', track.event(), prefix(track.event(), {
+    'ID': track.orderId(),
+    'Subtotal': track.subtotal(),
+    'Total': track.total()
+  }));
 
   // items
   window._kmq.push(function(){
     var km = window.KM;
     each(products, function(product, i){
       var track = new Track({ properties: product });
-      var item = {
-        'Purchased SKU': track.sku(),
-        'Purchased Product Name': track.name(),
-        'Purchased Category': track.category(),
-        'Purchased Quantity': track.quantity(),
-        'Purchased Price': track.price()
-      };
+      var item = prefix('Completed Order', toProduct(track));
       item._t = km.ts() + i;
       item._d = 1;
       km.set(item);
@@ -197,19 +195,19 @@ KISSmetrics.prototype.completedOrder = function(track){
 };
 
 /**
- * Prefix properties with the event name, then push.
+ * Prefix properties with the event name.
  *
  * @param {String} event
  * @param {Object} properties
  * @api private
  */
 
-function record(event, properties){
+function prefix(event, properties){
   var props = {};
   each(properties, function(key, val){
     props[event + ' - ' + key] = val;
   });
-  push('record', event, props);
+  return props;
 }
 
 /**

--- a/lib/kissmetrics.js
+++ b/lib/kissmetrics.js
@@ -146,7 +146,7 @@ KISSmetrics.prototype.alias = function (alias) {
  */
 
 KISSmetrics.prototype.viewedProduct = function(track){
-  push('record', 'Product Viewed', toProduct(track));
+  record('Product Viewed', toProduct(track));
 };
 
 /**
@@ -157,7 +157,7 @@ KISSmetrics.prototype.viewedProduct = function(track){
  */
 
 KISSmetrics.prototype.addedProduct = function(track){
-  push('record', 'Product Added', toProduct(track));
+  record('Product Added', toProduct(track));
 };
 
 /**
@@ -168,12 +168,12 @@ KISSmetrics.prototype.addedProduct = function(track){
  */
 
 KISSmetrics.prototype.completedOrder = function(track){
-  var orderId = track.orderId();
   var products = track.products();
 
   // transaction
   push('record', 'Purchased', {
     'Order ID': track.orderId(),
+    'Order Subtotal': track.subtotal(),
     'Order Total': track.total()
   });
 
@@ -182,14 +182,35 @@ KISSmetrics.prototype.completedOrder = function(track){
     var km = window.KM;
     each(products, function(product, i){
       var track = new Track({ properties: product });
-      var item = toProduct(track);
-      item['Order ID'] = orderId;
+      var item = {
+        'Purchased SKU': track.sku(),
+        'Purchased Product Name': track.name(),
+        'Purchased Category': track.category(),
+        'Purchased Quantity': track.quantity(),
+        'Purchased Price': track.price()
+      };
       item._t = km.ts() + i;
       item._d = 1;
       km.set(item);
     });
   });
 };
+
+/**
+ * Prefix properties with the event name, then push.
+ *
+ * @param {String} event
+ * @param {Object} properties
+ * @api private
+ */
+
+function record(event, properties){
+  var props = {};
+  each(properties, function(key, val){
+    props[event + ' - ' + key] = val;
+  });
+  push('record', event, props);
+}
 
 /**
  * Get a product from the given `track`.
@@ -201,9 +222,10 @@ KISSmetrics.prototype.completedOrder = function(track){
 
 function toProduct(track){
   return {
-    Quantity: track.quantity(),
-    Price: track.price(),
+    SKU: track.sku(),
     Name: track.name(),
-    SKU: track.sku()
+    Price: track.price(),
+    Category: track.category(),
+    Quantity: track.quantity()
   };
 }

--- a/lib/kissmetrics.js
+++ b/lib/kissmetrics.js
@@ -92,13 +92,7 @@ KISSmetrics.prototype.page = function (page) {
   // named pages
   if (name && opts.trackPages) {
     var track = page.track(name);
-    var props = track.properties();
-    props.Title = document.title;
-    props.Path = window.location.pathname;
-    props.URL = window.location.href;
-    delete props.category;
-    if (this.options.prefixEventProperties) props = prefix(name, props);
-    push('record', track.event(), props);
+    this.track(track);
   }
 };
 
@@ -124,9 +118,11 @@ KISSmetrics.prototype.identify = function (identify) {
  */
 
 KISSmetrics.prototype.track = function (track) {
-  var props = track.properties({ revenue: 'Billing Amount' });
-  if (this.options.prefixEventProperties) props = prefix(track.event(), props);
-  push('record', track.event(), props);
+  var mapping = { revenue: 'Billing Amount' };
+  if (this.options.prefixEventProperties)
+    push('record', track.event(), prefix(track, mapping));
+  else
+    push('record', track.event(), track.properties(mapping));
 };
 
 
@@ -141,30 +137,6 @@ KISSmetrics.prototype.alias = function (alias) {
 };
 
 /**
- * Viewed product.
- *
- * @param {Track} track
- * @api private
- */
-
-KISSmetrics.prototype.viewedProduct = function(track){
-  var props = prefix(track.event(), toProduct(track));
-  push('record', track.event(), props);
-};
-
-/**
- * Product added.
- *
- * @param {Track} track
- * @api private
- */
-
-KISSmetrics.prototype.addedProduct = function(track){
-  var props = prefix(track.event(), toProduct(track));
-  push('record', track.event(), props);
-};
-
-/**
  * Completed order.
  *
  * @param {Track} track
@@ -175,18 +147,14 @@ KISSmetrics.prototype.completedOrder = function(track){
   var products = track.products();
 
   // transaction
-  push('record', track.event(), prefix(track.event(), {
-    'ID': track.orderId(),
-    'Subtotal': track.subtotal(),
-    'Total': track.total()
-  }));
+  push('record', track.event(), prefix(track));
 
   // items
   window._kmq.push(function(){
     var km = window.KM;
     each(products, function(product, i){
-      var temp = new Track({ properties: product });
-      var item = prefix(track.event(), toProduct(temp));
+      var temp = new Track({ event : track.event(), properties: product });
+      var item = prefix(temp);
       item._t = km.ts() + i;
       item._d = 1;
       km.set(item);
@@ -197,36 +165,18 @@ KISSmetrics.prototype.completedOrder = function(track){
 /**
  * Prefix properties with the event name.
  *
- * @param {String} event
- * @param {Object} properties
+ * @param {Track} track
+ * @param {Object} mapping
  * @api private
  */
 
-function prefix(event, properties){
+function prefix(track, mapping){
+  var event = track.event();
+  var properties = mapping ? track.properties(mapping) : track.properties();
   var props = {};
   each(properties, function(key, val){
-    if (key === 'Billing Amount')
-      props[key] = val;
-    else
-      props[event + ' - ' + key] = val;
+    if (key === 'Billing Amount') props[key] = val;
+    else props[event + ' - ' + key] = val;
   });
   return props;
-}
-
-/**
- * Get a product from the given `track`.
- *
- * @param {Track} track
- * @return {Object}
- * @api private
- */
-
-function toProduct(track){
-  return {
-    SKU: track.sku(),
-    Name: track.name(),
-    Price: track.price(),
-    Category: track.category(),
-    Quantity: track.quantity()
-  };
 }

--- a/test/integrations/kissmetrics.js
+++ b/test/integrations/kissmetrics.js
@@ -43,7 +43,7 @@ describe('KISSmetrics', function () {
       .global('KM')
       .global('_kmil')
       .option('apiKey', '')
-      .option('trackNamedPages', true);
+      .option('trackPages', true);
   });
 
   it('should create window._kmq', function () {
@@ -81,29 +81,16 @@ describe('KISSmetrics', function () {
     });
 
     it('should track named pages by default', function () {
-      test(kissmetrics).page(null, 'Name');
-      assert(window._kmq.push.calledWith(['record', 'Viewed Name Page', { name: 'Name' }]));
-    });
-
-    it('should track named pages with categories', function () {
-      test(kissmetrics).page('Category', 'Name');
-      assert(window._kmq.push.calledWith(['record', 'Viewed Category Name Page', {
-        category: 'Category',
-        name: 'Name'
+      test(kissmetrics).page('Name');
+      assert(window._kmq.push.calledWith(['record', 'Viewed Name Page', {
+        'Name - Title': document.title,
+        'Name - Path': window.location.pathname,
+        'Name - URL': window.location.href
       }]));
     });
 
-    it('should track categorized pages by default', function () {
-      test(kissmetrics).page('Category', 'Name');
-      assert(window._kmq.push.calledWith(['record', 'Viewed Category Page', {
-        category: 'Category',
-        name: 'Name'
-      }]));
-    });
-
-    it('should not track a named or categorized page when the option is off', function () {
-      kissmetrics.options.trackNamedPages = false;
-      kissmetrics.options.trackCategorizedPages = false;
+    it('should not track a named pages when the option is off', function () {
+      kissmetrics.options.trackPages = false;
       test(kissmetrics).page(null, 'Name');
       test(kissmetrics).page('Category', 'Name');
       assert(!window._kmq.push.called);

--- a/test/integrations/kissmetrics.js
+++ b/test/integrations/kissmetrics.js
@@ -180,12 +180,12 @@ describe('KISSmetrics', function () {
       test(kissmetrics)
         .track('viewed product', { sku: 1, name: 'item', category: 'category', price: 9 })
         .called(window._kmq.push)
-        .with(['record', 'Product Viewed', {
-          'Product Viewed - SKU': 1,
-          'Product Viewed - Name': 'item',
-          'Product Viewed - Category': 'category',
-          'Product Viewed - Price': 9,
-          'Product Viewed - Quantity': 1
+        .with(['record', 'viewed product', {
+          'viewed product - SKU': 1,
+          'viewed product - Name': 'item',
+          'viewed product - Category': 'category',
+          'viewed product - Price': 9,
+          'viewed product - Quantity': 1
         }]);
     })
 
@@ -193,12 +193,12 @@ describe('KISSmetrics', function () {
       test(kissmetrics)
         .track('added product', { sku: 1, name: 'item', category: 'category', price: 9, quantity: 2 })
         .called(window._kmq.push)
-        .with(['record', 'Product Added', {
-          'Product Added - SKU': 1,
-          'Product Added - Name': 'item',
-          'Product Added - Category': 'category',
-          'Product Added - Price': 9,
-          'Product Added - Quantity': 2
+        .with(['record', 'added product', {
+          'added product - SKU': 1,
+          'added product - Name': 'item',
+          'added product - Category': 'category',
+          'added product - Price': 9,
+          'added product - Quantity': 2
         }])
     })
 
@@ -220,10 +220,10 @@ describe('KISSmetrics', function () {
           }]
         });
 
-      assert(window._kmq.push.args[0], ['record', 'Completed Order', {
-        'Completed Order - ID': '12074d48',
-        'Completed Order - Subtotal': 150,
-        'Completed Order - Total': 166
+      assert(window._kmq.push.args[0], ['record', 'completed order', {
+        'completed order - ID': '12074d48',
+        'completed order - Subtotal': 150,
+        'completed order - Total': 166
       }]);
     })
 
@@ -253,21 +253,21 @@ describe('KISSmetrics', function () {
       fn();
 
       assert(equals(window.KM.set.args[0][0], {
-        'Completed Order - SKU': '40bcda73',
-        'Completed Order - Name': 'my-product',
-        'Completed Order - Category': 'my-category',
-        'Completed Order - Price': 75,
-        'Completed Order - Quantity': 1,
+        'completed order - SKU': '40bcda73',
+        'completed order - Name': 'my-product',
+        'completed order - Category': 'my-category',
+        'completed order - Price': 75,
+        'completed order - Quantity': 1,
         _t: 0,
         _d: 1
       }));
 
       assert(equals(window.KM.set.args[1][0], {
-        'Completed Order - SKU': '64346fc6',
-        'Completed Order - Name': 'other-product',
-        'Completed Order - Category': 'my-other-category',
-        'Completed Order - Price': 75,
-        'Completed Order - Quantity': 1,
+        'completed order - SKU': '64346fc6',
+        'completed order - Name': 'other-product',
+        'completed order - Category': 'my-other-category',
+        'completed order - Price': 75,
+        'completed order - Quantity': 1,
         _t: 1,
         _d: 1
       }));

--- a/test/integrations/kissmetrics.js
+++ b/test/integrations/kissmetrics.js
@@ -43,7 +43,8 @@ describe('KISSmetrics', function () {
       .global('KM')
       .global('_kmil')
       .option('apiKey', '')
-      .option('trackPages', true);
+      .option('trackPages', true)
+      .option('prefixEventProperties', true);
   });
 
   it('should create window._kmq', function () {
@@ -81,15 +82,18 @@ describe('KISSmetrics', function () {
     });
 
     it('should track named pages by default', function () {
-      test(kissmetrics).page('Name');
+      test(kissmetrics).page(null, 'Name', {
+        title : document.title,
+        url : window.location.href
+      });
       assert(window._kmq.push.calledWith(['record', 'Viewed Name Page', {
-        'Name - Title': document.title,
-        'Name - Path': window.location.pathname,
-        'Name - URL': window.location.href
+        'Viewed Name Page - title': document.title,
+        'Viewed Name Page - url'  : window.location.href,
+        'Viewed Name Page - name' : 'Name'
       }]));
     });
 
-    it('should not track a named pages when the option is off', function () {
+    it('should not track a named page when the option is off', function () {
       kissmetrics.options.trackPages = false;
       test(kissmetrics).page(null, 'Name');
       test(kissmetrics).page('Category', 'Name');
@@ -170,11 +174,10 @@ describe('KISSmetrics', function () {
         .track('viewed product', { sku: 1, name: 'item', category: 'category', price: 9 })
         .called(window._kmq.push)
         .with(['record', 'viewed product', {
-          'viewed product - SKU': 1,
-          'viewed product - Name': 'item',
-          'viewed product - Category': 'category',
-          'viewed product - Price': 9,
-          'viewed product - Quantity': 1
+          'viewed product - sku': 1,
+          'viewed product - name': 'item',
+          'viewed product - category': 'category',
+          'viewed product - price': 9
         }]);
     })
 
@@ -183,11 +186,11 @@ describe('KISSmetrics', function () {
         .track('added product', { sku: 1, name: 'item', category: 'category', price: 9, quantity: 2 })
         .called(window._kmq.push)
         .with(['record', 'added product', {
-          'added product - SKU': 1,
-          'added product - Name': 'item',
-          'added product - Category': 'category',
-          'added product - Price': 9,
-          'added product - Quantity': 2
+          'added product - sku': 1,
+          'added product - name': 'item',
+          'added product - category': 'category',
+          'added product - price': 9,
+          'added product - quantity': 2
         }])
     })
 
@@ -196,6 +199,7 @@ describe('KISSmetrics', function () {
         .track('completed order', {
           orderId: '12074d48',
           tax: 16,
+          total: 166,
           products: [{
             sku: '40bcda73',
             name: 'my-product',
@@ -210,9 +214,8 @@ describe('KISSmetrics', function () {
         });
 
       assert(window._kmq.push.args[0], ['record', 'completed order', {
-        'completed order - ID': '12074d48',
-        'completed order - Subtotal': 150,
-        'completed order - Total': 166
+        'completed order - sku': '12074d48',
+        'completed order - total': 166
       }]);
     })
 
@@ -242,21 +245,21 @@ describe('KISSmetrics', function () {
       fn();
 
       assert(equals(window.KM.set.args[0][0], {
-        'completed order - SKU': '40bcda73',
-        'completed order - Name': 'my-product',
-        'completed order - Category': 'my-category',
-        'completed order - Price': 75,
-        'completed order - Quantity': 1,
+        'completed order - sku': '40bcda73',
+        'completed order - name': 'my-product',
+        'completed order - category': 'my-category',
+        'completed order - price': 75,
+        'completed order - quantity': 1,
         _t: 0,
         _d: 1
       }));
 
       assert(equals(window.KM.set.args[1][0], {
-        'completed order - SKU': '64346fc6',
-        'completed order - Name': 'other-product',
-        'completed order - Category': 'my-other-category',
-        'completed order - Price': 75,
-        'completed order - Quantity': 1,
+        'completed order - sku': '64346fc6',
+        'completed order - name': 'other-product',
+        'completed order - category': 'my-other-category',
+        'completed order - price': 75,
+        'completed order - quantity': 1,
         _t: 1,
         _d: 1
       }));

--- a/test/integrations/kissmetrics.js
+++ b/test/integrations/kissmetrics.js
@@ -220,10 +220,10 @@ describe('KISSmetrics', function () {
           }]
         });
 
-      assert(window._kmq.push.args[0], ['record', 'Purchased', {
-        'Order ID': '12074d48',
-        'Order Subtotal': 150,
-        'Order Total': 166
+      assert(window._kmq.push.args[0], ['record', 'Completed Order', {
+        'Completed Order - ID': '12074d48',
+        'Completed Order - Subtotal': 150,
+        'Completed Order - Total': 166
       }]);
     })
 
@@ -253,21 +253,21 @@ describe('KISSmetrics', function () {
       fn();
 
       assert(equals(window.KM.set.args[0][0], {
-        'Purchased SKU': '40bcda73',
-        'Purchased Product Name': 'my-product',
-        'Purchased Category': 'my-category',
-        'Purchased Price': 75,
-        'Purchased Quantity': 1,
+        'Completed Order - SKU': '40bcda73',
+        'Completed Order - Name': 'my-product',
+        'Completed Order - Category': 'my-category',
+        'Completed Order - Price': 75,
+        'Completed Order - Quantity': 1,
         _t: 0,
         _d: 1
       }));
 
       assert(equals(window.KM.set.args[1][0], {
-        'Purchased SKU': '64346fc6',
-        'Purchased Product Name': 'other-product',
-        'Purchased Category': 'my-other-category',
-        'Purchased Price': 75,
-        'Purchased Quantity': 1,
+        'Completed Order - SKU': '64346fc6',
+        'Completed Order - Name': 'other-product',
+        'Completed Order - Category': 'my-other-category',
+        'Completed Order - Price': 75,
+        'Completed Order - Quantity': 1,
         _t: 1,
         _d: 1
       }));

--- a/test/integrations/kissmetrics.js
+++ b/test/integrations/kissmetrics.js
@@ -178,20 +178,27 @@ describe('KISSmetrics', function () {
 
     it('should track viewed product', function(){
       test(kissmetrics)
-        .track('viewed product', { sku: 1, name: 'item', price: 9 })
+        .track('viewed product', { sku: 1, name: 'item', category: 'category', price: 9 })
         .called(window._kmq.push)
-        .with(['record', 'Product Viewed', { SKU: 1, Name: 'item', Price: 9, Quantity: 1 }]);
+        .with(['record', 'Product Viewed', {
+          'Product Viewed - SKU': 1,
+          'Product Viewed - Name': 'item',
+          'Product Viewed - Category': 'category',
+          'Product Viewed - Price': 9,
+          'Product Viewed - Quantity': 1
+        }]);
     })
 
     it('should track added product', function(){
       test(kissmetrics)
-        .track('added product', { sku: 1, name: 'item', price: 9, quantity: 2 })
+        .track('added product', { sku: 1, name: 'item', category: 'category', price: 9, quantity: 2 })
         .called(window._kmq.push)
         .with(['record', 'Product Added', {
-          SKU: 1,
-          Name: 'item',
-          Price: 9,
-          Quantity: 2
+          'Product Added - SKU': 1,
+          'Product Added - Name': 'item',
+          'Product Added - Category': 'category',
+          'Product Added - Price': 9,
+          'Product Added - Quantity': 2
         }])
     })
 
@@ -199,7 +206,7 @@ describe('KISSmetrics', function () {
       test(kissmetrics)
         .track('completed order', {
           orderId: '12074d48',
-          total: 150,
+          tax: 16,
           products: [{
             sku: '40bcda73',
             name: 'my-product',
@@ -215,7 +222,8 @@ describe('KISSmetrics', function () {
 
       assert(window._kmq.push.args[0], ['record', 'Purchased', {
         'Order ID': '12074d48',
-        'Order Total': 150
+        'Order Subtotal': 150,
+        'Order Total': 166
       }]);
     })
 
@@ -223,15 +231,17 @@ describe('KISSmetrics', function () {
       test(kissmetrics)
         .track('completed order', {
           orderId: '12074d48',
-          total: 150,
+          tax: 16,
           products: [{
             sku: '40bcda73',
             name: 'my-product',
+            category: 'my-category',
             price: 75,
             quantity: 1
           }, {
             sku: '64346fc6',
             name: 'other-product',
+            category: 'my-other-category',
             price: 75,
             quantity: 1
           }]
@@ -243,21 +253,21 @@ describe('KISSmetrics', function () {
       fn();
 
       assert(equals(window.KM.set.args[0][0], {
-        'Order ID': '12074d48',
-        SKU: '40bcda73',
-        Name: 'my-product',
-        Price: 75,
-        Quantity: 1,
+        'Purchased SKU': '40bcda73',
+        'Purchased Product Name': 'my-product',
+        'Purchased Category': 'my-category',
+        'Purchased Price': 75,
+        'Purchased Quantity': 1,
         _t: 0,
         _d: 1
       }));
 
       assert(equals(window.KM.set.args[1][0], {
-        'Order ID': '12074d48',
-        SKU: '64346fc6',
-        Name: 'other-product',
-        Price: 75,
-        Quantity: 1,
+        'Purchased SKU': '64346fc6',
+        'Purchased Product Name': 'other-product',
+        'Purchased Category': 'my-other-category',
+        'Purchased Price': 75,
+        'Purchased Quantity': 1,
         _t: 1,
         _d: 1
       }));

--- a/test/integrations/kissmetrics.js
+++ b/test/integrations/kissmetrics.js
@@ -144,7 +144,9 @@ describe('KISSmetrics', function () {
 
     it('should send an event and properties', function () {
       test(kissmetrics).track('event', { property: true });
-      assert(window._kmq.push.calledWith(['record', 'event', { property: true }]));
+      assert(window._kmq.push.calledWith(['record', 'event', {
+        'event - property': true
+      }]));
     });
 
     it('should alias revenue to "Billing Amount"', function () {


### PR DESCRIPTION
@yields @ianstormtaylor this is the one that will need a migration...

there are a few changes here, as requested by master of kiss @DirtyAnalytics:
1. page category makes no sense
2. critical page properties are url, path and title... should be prefixed by category/name of page
3. events need prefixed properties

just getting this rolling, i assume we'll need to adjust things. in particular i'm unsure of how to handle category/name properly for page. i think @DirtyAnalytics has a point that page category doesn't make a lot of sense as a top-level argument.
