### PR TITLE
refactor to use .revenue instead of .revenue || .total for analytics.js-private#85

### DIFF
--- a/lib/adroll.js
+++ b/lib/adroll.js
@@ -92,7 +92,7 @@ AdRoll.prototype.load = function (callback) {
 
 AdRoll.prototype.track = function(track){
   var events = this.options.events;
-  var total = track.revenue() || track.total();
+  var total = track.revenue();
   var event = track.event();
   if (has.call(events, event)) event = events[event];
   window.__adroll.record_user({


### PR DESCRIPTION
@calvinfo @yields looks like there's only one place in here
