### PR TITLE
Add/remarketing for #122

### DIFF
--- a/lib/adwords.js
+++ b/lib/adwords.js
@@ -25,6 +25,7 @@ var has = Object.prototype.hasOwnProperty;
 var AdWords = exports.Integration = integration('AdWords')
   .readyOnLoad()
   .option('conversionId', '')
+  .option('remarketing', false)
   .option('events', {});
 
 /**
@@ -35,7 +36,9 @@ var AdWords = exports.Integration = integration('AdWords')
  */
 
 AdWords.prototype.load = function(fn){
-  onbody(fn);
+  onbody(function(){
+
+  });
 };
 
 /**
@@ -88,7 +91,7 @@ AdWords.prototype.conversion = function(obj, fn){
   window.google_conversion_color = 'ffffff';
   window.google_conversion_label = obj.label;
   window.google_conversion_value = obj.value;
-  window.google_remarketing_only = false;
+  window.google_remarketing_only = this.options.remarketing;
   load('//www.googleadservices.com/pagead/conversion.js', fn);
 
   function append(str){

--- a/lib/adwords.js
+++ b/lib/adwords.js
@@ -36,9 +36,7 @@ var AdWords = exports.Integration = integration('AdWords')
  */
 
 AdWords.prototype.load = function(fn){
-  onbody(function(){
-
-  });
+  onbody(fn);
 };
 
 /**
@@ -50,6 +48,21 @@ AdWords.prototype.load = function(fn){
 
 AdWords.prototype.loaded = function(){
   return !! document.body;
+};
+
+
+/**
+ * Page.
+ *
+ * http://clicky.com/help/customization#/help/custom/manual
+ *
+ * @param {Page} page
+ */
+
+AdWords.prototype.page = function(page){
+  var remarketing = this.options.remarketing;
+  var id = this.options.conversionId;
+  if (remarketing) this.remarketing(id);
 };
 
 /**
@@ -74,7 +87,8 @@ AdWords.prototype.track = function(track){
 /**
  * Report AdWords conversion.
  *
- * @param {Object} globals
+ * @param {Object} obj
+ * @param {Function} [fn]
  * @api private
  */
 
@@ -91,7 +105,7 @@ AdWords.prototype.conversion = function(obj, fn){
   window.google_conversion_color = 'ffffff';
   window.google_conversion_label = obj.label;
   window.google_conversion_value = obj.value;
-  window.google_remarketing_only = this.options.remarketing;
+  window.google_remarketing_only = false;
   load('//www.googleadservices.com/pagead/conversion.js', fn);
 
   function append(str){
@@ -103,6 +117,21 @@ AdWords.prototype.conversion = function(obj, fn){
     document.write = write;
     self.reporting = null;
   }
+};
+
+/**
+ * Add remarketing.
+ *
+ * @param {String} id Conversion ID
+ * @param {Function} [fn]
+ * @api private
+ */
+
+AdWords.prototype.remarketing = function(id){
+  window.google_conversion_id = id;
+  // window.google_custom_params = window.google_tag_params;
+  window.google_remarketing_only = true;
+  load('//www.googleadservices.com/pagead/conversion.js');
 };
 
 /**

--- a/test/integrations/adwords.js
+++ b/test/integrations/adwords.js
@@ -25,6 +25,8 @@ describe('AdWords', function(){
     test(adwords)
       .name('AdWords')
       .readyOnLoad()
+      .option('conversionId', '')
+      .option('remarketing', false)
       .option('events', {});
   })
 
@@ -67,6 +69,29 @@ describe('AdWords', function(){
         assert(write == document.write);
         done();
       });
+    })
+  })
+
+  describe('#page', function(){
+    beforeEach(function(done){
+      adwords.on('ready', done);
+      sinon.spy(adwords, 'remarketing');
+      adwords.initialize();
+    })
+
+    afterEach(function(){
+      adwords.options.remarketing = false;
+    });
+
+    it('should not load remarketing if option is not on', function(){
+      test(adwords).page();
+      assert(!adwords.remarketing.called);
+    })
+
+    it('should load remarketing if option is on', function(){
+      adwords.options.remarketing = true;
+      test(adwords).page();
+      assert(adwords.remarketing.calledOnce);
     })
   })
 


### PR DESCRIPTION
/cc @DirtyAnalytics @reinpk how does this look for supporting remarketing? Is the logic correct? Basically, the remarketing script will be loaded on `.page`. And it works just like the `.conversion()`, the main difference being that you aren't passing all of those extra `google_*` variables.

Questions:
- Does it matter passing those extra variables? If not, we can pass simplify the internal code some.
- Do we need that `self.reporting` logic in `.conversion` for remarketing as well?
