### PR TITLE
Quantcast: fix exception in identify()

### DIFF
--- a/lib/quantcast.js
+++ b/lib/quantcast.js
@@ -116,7 +116,7 @@ Quantcast.prototype.page = function (page) {
 Quantcast.prototype.identify = function (identify) {
   // edit the initial quantcast settings
   var id = identify.userId();
-  if (id) window._qevents[0].uid = id;
+  if (id && !!window._qevents[0]) window._qevents[0].uid = id;
 };
 
 


### PR DESCRIPTION
In some circumstances, if identify() is called after the Quantcast
script is loaded, the queue may be empty and thus the identify call may
throw an exception. This commit adds some more robustness to only add
the `uid` property if the item exists.

Fixes https://github.com/segmentio/analytics.js-integrations/issues/165
