### PR TITLE
google-analytics: fix custom metrics, remove from page/track/group

### DIFF
--- a/lib/google-analytics.js
+++ b/lib/google-analytics.js
@@ -80,9 +80,6 @@ GA.on('construct', function (integration) {
 
 GA.prototype.initialize = function () {
   var opts = this.options;
-  var gMetrics = metrics(group.traits(), opts);
-  var uMetrics = metrics(user.traits(), opts);
-  var custom;
 
   // setup the tracker globals
   window.GoogleAnalyticsObject = 'ga';
@@ -106,15 +103,15 @@ GA.prototype.initialize = function () {
   // send global id
   if (opts.sendUserId && user.id()) {
     window.ga('set', '&uid', user.id());
-  }  
+  }
 
   // anonymize after initializing, otherwise a warning is shown
   // in google analytics debugger
   if (opts.anonymizeIp) window.ga('set', 'anonymizeIp', true);
 
   // custom dimensions & metrics
-  if (length(gMetrics)) window.ga('set', gMetrics);
-  if (length(uMetrics)) window.ga('set', uMetrics);
+  var custom = metrics(user.traits(), opts);
+  if (length(custom)) window.ga('set', custom);
 
   this.load();
 };
@@ -159,14 +156,12 @@ GA.prototype.page = function (page) {
 
   this._category = category; // store for later
 
-  // add metrics and dimensions
-  var hit = metrics(page.properties(), this.options);
-  hit.page = path(props, this.options);
-  hit.title = name || props.title;
-  hit.location = props.url;
-
   // send
-  window.ga('send', 'pageview', hit);
+  window.ga('send', 'pageview', {
+    page: path(props, this.options),
+    title: name || props.title,
+    location: props.url
+  });
 
   // categorized pages
   if (category && this.options.trackCategorizedPages) {
@@ -195,18 +190,13 @@ GA.prototype.track = function (track, options) {
   var opts = options || track.options(this.name);
   var props = track.properties();
 
-  // metrics & dimensions
-  var event = metrics(props, this.options);
-
-  // event
-  event.eventAction = track.event();
-  event.eventCategory = props.category || this._category || 'All';
-  event.eventLabel = props.label;
-  event.eventValue = formatValue(props.value || track.revenue());
-  event.nonInteraction = props.noninteraction || opts.noninteraction;
-
-  // send
-  window.ga('send', 'event', event);
+  window.ga('send', 'event', {
+    eventAction: track.event(),
+    eventCategory: props.category || this._category || 'All',
+    eventLabel: props.label,
+    eventValue: formatValue(props.value || track.revenue()),
+    nonInteraction: props.noninteraction || opts.noninteraction
+  });
 };
 
 /**
@@ -453,15 +443,15 @@ function formatValue (value) {
 
 /**
  * Map google's custom dimensions & metrics with `obj`.
- * 
+ *
  * Example:
- * 
- *      metrics({ revenue: 1.9 }, { { metrics : { metric8: 'revenue' } });
+ *
+ *      metrics({ revenue: 1.9 }, { { metrics : { revenue: 'metric8' } });
  *      // => { metric8: 1.9 }
- * 
+ *
  *      metrics({ revenue: 1.9 }, {});
  *      // => {}
- * 
+ *
  * @param {Object} obj
  * @param {Object} data
  * @return {Object|null}
@@ -475,10 +465,11 @@ function metrics(obj, data){
   var ret = {};
 
   for (var i = 0; i < names.length; ++i) {
-    var name = metrics[names[i]] || dimensions[names[i]];
+    var name = names[i];
+    var key = metrics[name] || dimensions[name];
     var value = dot(obj, name);
     if (null == value) continue;
-    ret[names[i]] = value;
+    ret[key] = value;
   }
 
   return ret;

--- a/test/integrations/google-analytics.js
+++ b/test/integrations/google-analytics.js
@@ -110,8 +110,8 @@ describe('Google Analytics', function () {
       })
 
       it('should map custom dimensions & metrics using user.traits()', function(){
-        ga.options.metrics = { metric1: 'firstName', metric2: 'last_name' };
-        ga.options.dimensions = { dimension2: 'Age' };
+        ga.options.metrics = { firstName: 'metric1', last_name: 'metric2' };
+        ga.options.dimensions = { Age: 'dimension2' };
         analytics.user().traits({ firstName: 'John', lastName: 'Doe', age: 20 });
         ga.initialize();
 
@@ -119,19 +119,6 @@ describe('Google Analytics', function () {
           metric1: 'John',
           metric2: 'Doe',
           dimension2: 20
-        }]));
-      })
-
-      it('should map custom dimensions & metrics using group.traits()', function(){
-        ga.options.metrics = { metric2: 'Employees' };
-        ga.options.dimensions = { dimension3: 'industry', dimension4: 'age' };
-        analytics.group().traits({ industry: 'tech', employees: 12, age: 0 });
-        ga.initialize();
-
-        assert(equal(window.ga.q[2], ['set', {
-          metric2: 12,
-          dimension3: 'tech',
-          dimension4: 0
         }]));
       })
 
@@ -248,34 +235,6 @@ describe('Google Analytics', function () {
         test(ga).page('Category', 'Name');
         assert(window.ga.calledTwice);
       });
-
-      it('should map properties to custom dimensions', function(){
-        ga.options.trackNamedPages = false;
-        ga.options.dimensions = { dimension1: 'name', dimension2: 'author' };
-        test(ga).page(null, 'Blog Post', { author: 'John Doe' });
-
-        assert(equal(window.ga.args[0], ['send', 'pageview', {
-          dimension2: 'John Doe',
-          dimension1: 'Blog Post',
-          location: undefined,
-          page: undefined,
-          title: 'Blog Post'
-        }]))
-      })
-
-      it('should map properties to custom metrics', function(){
-        ga.options.trackNamedPages = false;
-        ga.options.metrics = { metric200: 'mymetric', metric9: 'otherMetric' };
-        test(ga).page(null, 'Name', { mymetric: 0, other_metric: 9 });
-
-        assert(equal(window.ga.args[0], ['send', 'pageview', {
-          location: undefined,
-          page: undefined,
-          title: 'Name',
-          metric9: 9,
-          metric200: 0
-        }]));
-      })
     });
 
     describe('#track', function () {
@@ -384,52 +343,6 @@ describe('Google Analytics', function () {
           nonInteraction: true
         }));
       });
-
-      it('should map properties to custom dimensions', function(){
-        ga.options.dimensions = {
-          dimension200: 'userAge',
-          dimension1: 'level'
-        };
-        test(ga).track('level up', {
-          user_age: 28,
-          level: 2
-        });
-
-        assert(equal(window.ga.args[0], ['send', 'event', {
-          dimension1: 2,
-          dimension200: 28,
-          eventAction: 'level up',
-          eventCategory: 'All',
-          nonInteraction: undefined,
-          eventValue: 0,
-          eventLabel: undefined
-        }]));
-      })
-
-      it('should map properties to custom metrics', function(){
-        ga.options.metrics = {
-          metric1: 'user_name',
-          metric2: 'user_age',
-          metric3: 'user level'
-        };
-
-        test(ga).track('level up', {
-          userAge: 20,
-          userLevel: 2,
-          user_name: 'John Doe'
-        });
-
-        assert(equal(window.ga.args[0], ['send', 'event', {
-          eventAction: 'level up',
-          eventCategory: 'All',
-          eventLabel: undefined,
-          eventValue: 0,
-          metric1: 'John Doe',
-          metric2: 20,
-          metric3: 2,
-          nonInteraction: undefined
-        }]));
-      })
     });
 
     describe('ecommerce', function(){


### PR DESCRIPTION
- remove custom metrics from `page`
- remove custom metrics from `track`
- remove custom metrics in `initialize` from `group.traits`
- fix mapping order to match Segment interface

cc @lancejpollard @calvinfo @DirtyAnalytics @raphael-parker 

needed for a few different customers
