### PR TITLE
fix kissmetrics page tracking

### DIFF
--- a/lib/kissmetrics.js
+++ b/lib/kissmetrics.js
@@ -23,7 +23,6 @@ module.exports = exports = function (analytics) {
  */
 
 var KISSmetrics = exports.Integration = integration('KISSmetrics')
-  .assumesPageview()
   .readyOnInitialize()
   .global('_kmq')
   .global('KM')

--- a/test/integrations/kissmetrics.js
+++ b/test/integrations/kissmetrics.js
@@ -37,7 +37,6 @@ describe('KISSmetrics', function () {
   it('should have the right settings', function () {
     test(kissmetrics)
       .name('KISSmetrics')
-      .assumesPageview()
       .readyOnInitialize()
       .global('_kmq')
       .global('KM')


### PR DESCRIPTION
This fixes a problem we're seeing with KISSmetrics. Basically we end up in a bad situation, because KISSmetrics tracks pageviews internally to their library, and they do track a pageview on load. Which means they _should_ do `assumesPageview`.

However, since we added the named and categorized event handling to the integration, people are depending on every page call. And in this case, they aren't getting fired for the very first pageview, since it gets swallow (on purpose) by `assumesPageview`.

So for now, I'm removing `assumesPageview` from it. It's not technically correct, but when if we ever do solve it properly it will be equivalent in terms of forward compat, so it's okay to make for right now to quick fix the problem.

@lancejpollard @calvinfo @DirtyAnalytics 
