### PR TITLE
refactor kenshoo to only support `.track()` with named events

### DIFF
--- a/component.json
+++ b/component.json
@@ -17,6 +17,7 @@
     "component/clone": "0.1.1",
     "component/domify": "1.2.0",
     "component/each": "0.0.1",
+    "component/indexof": "0.0.3",
     "component/once": "0.0.1",
     "component/throttle": "0.0.2",
     "component/type": "1.0.0",

--- a/lib/kenshoo.js
+++ b/lib/kenshoo.js
@@ -5,6 +5,7 @@
 
 var integration = require('integration');
 var load = require('load-script');
+var indexof = require('indexof');
 var is = require('is');
 
 /**
@@ -24,8 +25,7 @@ var Kenshoo = exports.Integration = integration('Kenshoo')
   .global('k_trackevent')
   .option('cid', '')
   .option('subdomain', '')
-  .option('trackNamedPages', true)
-  .option('trackCategorizedPages', true);
+  .option('events', []);
 
 /**
  * Initialize.
@@ -61,55 +61,10 @@ Kenshoo.prototype.load = function(callback){
 };
 
 /**
- * Completed order.
- *
- * https://github.com/jorgegorka/the_tracker/blob/master/lib/the_tracker/trackers/kenshoo.rb
- *
- * @param {Track} track
- * @api private
- */
-
-Kenshoo.prototype.completedOrder = function(track){
-  this._track(track, { val: track.total() });
-};
-
-/**
- * Page.
- *
- * @param {Page} page
- */
-
-Kenshoo.prototype.page = function(page){
-  var category = page.category();
-  var name = page.name();
-  var fullName = page.fullName();
-  var isNamed = (name && this.options.trackNamedPages);
-  var isCategorized = (category && this.options.trackCategorizedPages);
-  var track;
-
-  if (name && ! this.options.trackNamedPages) {
-    return;
-  }
-
-  if (category && ! this.options.trackCategorizedPages) {
-    return;
-  }
-
-  if (isNamed && isCategorized) {
-    track = page.track(fullName);
-  } else if (isNamed) {
-    track = page.track(name);
-  } else if (isCategorized) {
-    track = page.track(category);
-  } else {
-    track = page.track();
-  }
-
-  this._track(track);
-};
-
-/**
  * Track.
+ *
+ * Only tracks events if they are listed in the events array option.
+ * We've asked for docs a few times but no go :/
  *
  * https://github.com/jorgegorka/the_tracker/blob/master/lib/the_tracker/trackers/kenshoo.rb
  *
@@ -117,29 +72,19 @@ Kenshoo.prototype.page = function(page){
  */
 
 Kenshoo.prototype.track = function(track){
-  this._track(track);
-};
-
-/**
- * Track a Kenshoo event.
- *
- * Private method for sending an event. We use it because `completedOrder`
- * can't call track directly (would result in an infinite loop).
- *
- * @param {track} event
- * @param {options} object
- */
-
-Kenshoo.prototype._track = function(track, options){
-  options = options || { val: track.revenue() };
+  var events = this.options.events;
+  var traits = track.traits();
+  var event = track.event();
+  var revenue = track.revenue() || 0;
+  if (!~indexof(events, event)) return;
 
   var params = [
     'id=' + this.options.cid,
-    'type=' + track.event(),
-    'val=' + (options.val || '0.0'),
-    'orderId=' + (track.orderId() || ''),
-    'promoCode=' + (track.coupon() || ''),
-    'valueCurrency=' + (track.currency() || ''),
+    'type=conv',
+    'val=' + revenue,
+    'orderId=' + track.orderId(),
+    'promoCode=' + track.coupon(),
+    'valueCurrency=' + track.currency(),
 
     // Live tracking fields. Ignored for now (until we get documentation).
     'GCID=',

--- a/test/integrations/kenshoo.js
+++ b/test/integrations/kenshoo.js
@@ -1,4 +1,5 @@
-describe('Kenshoo', function () {
+
+describe('Kenshoo', function(){
 
   var analytics = require('analytics');
   var assert = require('assert');
@@ -13,40 +14,38 @@ describe('Kenshoo', function () {
     subdomain: '1223'
   };
 
-  beforeEach(function() {
+  beforeEach(function(){
     kenshoo = new Kenshoo.Integration(settings);
     kenshoo.initialize();
   });
 
-  afterEach(function() {
+  afterEach(function(){
     kenshoo.reset();
   });
 
-  it("should have the right settings", function() {
+  it('should have the right settings', function(){
     test(kenshoo)
       .name('Kenshoo')
       .readyOnLoad()
       .global('k_trackevent')
       .option('cid', '')
       .option('subdomain', '')
-      .option('trackCategorizedPages', true)
-      .option('trackNamedPages', true);
+      .option('events', []);
   });
 
-  describe("#initialize", function() {
-    beforeEach(function() {
+  describe('#initialize', function(){
+    beforeEach(function(){
       sinon.spy(kenshoo, 'load');
     });
 
-    it("should call #load", function() {
+    it('should call #load', function(){
       kenshoo.initialize();
       assert(kenshoo.load.called);
     });
   });
 
-  describe("#loaded", function() {
-
-    it("should test window.k_trackevent", function() {
+  describe('#loaded', function(){
+    it('should test window.k_trackevent', function(){
       assert( ! kenshoo.loaded());
       window.k_trackevent = {};
       assert( ! kenshoo.loaded());
@@ -55,16 +54,16 @@ describe('Kenshoo', function () {
     });
   });
 
-  describe("#load", function() {
-    beforeEach(function () {
+  describe('#load', function(){
+    beforeEach(function(){
       sinon.stub(kenshoo, 'load');
       kenshoo.initialize();
       kenshoo.load.restore();
     });
 
-    it('should change loaded state', function (done) {
+    it('should change loaded state', function(done){
       assert(!kenshoo.loaded());
-      kenshoo.load(function (err) {
+      kenshoo.load(function(err){
         if (err) return done(err);
         assert(kenshoo.loaded());
         done();
@@ -72,181 +71,58 @@ describe('Kenshoo', function () {
     });
   });
 
-  /**
-   * Helper fun to return Kenshoo params array.
-   */
-
-  function constructParams(params) {
-    return [
-      "id=" + settings.cid,
-      "type=" + params.type,
-      "val=" + params.val,
-      "orderId=" + params.orderId,
-      "promoCode=" + params.promoCode,
-      "valueCurrency=" + params.valueCurrency,
-
-      // Live tracking params (currently ignored).
-      "GCID=",
-      "kw=",
-      "product="
-    ];
-  }
-
-  describe("#completedOrder", function() {
-    beforeEach(function () {
+  describe('#track', function(){
+    beforeEach(function(){
       kenshoo.initialize();
       window.k_trackevent = sinon.stub();
     });
 
-    it("should send the correct tracking parameters", function() {
-      test(kenshoo).track('completed order', {
-        total: "42",
-        orderId: "84",
-        coupon: "rubberduck",
-        currency: "EUR",
-      });
-
-      assert(window.k_trackevent.calledWith(
-        constructParams({
-          type: "completed order",
-          val: "42",
-          orderId: "84",
-          promoCode: "rubberduck",
-          valueCurrency: "EUR"
-        }), settings.subdomain));
+    afterEach(function(){
+      kenshoo.options.events = [];
     });
 
-    it("should track `total` and not `revenue` as `val`", function() {
-      test(kenshoo).track('completed order', {
-        revenue: "1",
-        orderId: "84",
-        coupon: "rubberduck",
-        currency: "EUR",
+    it('should track custom events', function(){
+      kenshoo.options.events = [ 'event' ];
+      test(kenshoo).track('event', {
+        revenue: '42',
+        orderId: '84',
+        coupon: 'promo',
+        currency: 'EUR',
       });
 
-      assert(window.k_trackevent.calledWith(
-        constructParams({
-          type: "completed order",
-          val: "0.0", // default val
-          orderId: "84",
-          promoCode: "rubberduck",
-          valueCurrency: "EUR"
-        }), settings.subdomain));
+      assert(window.k_trackevent.calledWith([
+        'id=' + settings.cid,
+        'type=conv',
+        'val=42',
+        'orderId=84',
+        'promoCode=promo',
+        'valueCurrency=EUR',
+        'GCID=',
+        'kw=',
+        'product='
+      ], settings.subdomain));
+    });
+
+    it('should not track undefined events', function(){
+      test(kenshoo).track('random', {
+        revenue: '42',
+        orderId: '84',
+        coupon: 'promo',
+        currency: 'EUR',
+      });
+      
+      assert(!window.k_trackevent.called);
     });
   });
 
-  describe('#page', function () {
-    beforeEach(function () {
-      kenshoo.initialize();
+  describe('#page', function(){
+    beforeEach(function(){
       window.k_trackevent = sinon.stub();
     });
 
-    it('should track an unnamed, uncategorized page view', function () {
+    it('should not make any event calls', function(){
       test(kenshoo).page();
-      kenshoo.options.trackNamedPages = false;
-      test(kenshoo).page();
-      kenshoo.options.trackCategorizedPages = false;
-      test(kenshoo).page();
-
-      assert(window.k_trackevent.alwaysCalledWith(
-        constructParams({
-          type: "Loaded a Page",
-          val: "0.0",
-          orderId: "",
-          promoCode: "",
-          valueCurrency: "USD"
-        }), settings.subdomain));
-      assert(window.k_trackevent.calledThrice);
-    });
-
-
-    it('should track a named page', function () {
-      test(kenshoo).page(null, 'testName');
-       assert(window.k_trackevent.calledWith(
-        constructParams({
-          type: "Viewed testName Page",
-          val: "0.0",
-          orderId: "",
-          promoCode: "",
-          valueCurrency: "USD"
-        }), settings.subdomain));
-    });
-
-    it('should track a name + category page', function () {
-      test(kenshoo).page('testCategory', 'testName');
-       assert(window.k_trackevent.calledWith(
-        constructParams({
-          type: "Viewed testCategory testName Page",
-          val: "0.0",
-          orderId: "",
-          promoCode: "",
-          valueCurrency: "USD"
-        }), settings.subdomain));
-    });
-
-    it('should track a categorized page', function () {
-      test(kenshoo).page('testCategory');
-      assert(window.k_trackevent.calledWith(
-        constructParams({
-          type: "Viewed testCategory Page",
-          val: "0.0",
-          orderId: "",
-          promoCode: "",
-          valueCurrency: "USD"
-        }), settings.subdomain));
-    });
-
-    it('should not track a named or categorized page when the option is off', function () {
-      kenshoo.options.trackNamedPages = false;
-      kenshoo.options.trackCategorizedPages = false;
-      test(kenshoo).page(null, 'Name');
-      test(kenshoo).page('Category', 'Name');
-      assert(window.k_trackevent.notCalled);
-    });
-  });
-
-  describe("#track", function() {
-    beforeEach(function () {
-      kenshoo.initialize();
-      window.k_trackevent = sinon.stub();
-    });
-
-    it('should track an event', function () {
-      test(kenshoo).track('event');
-      var params = constructParams({
-         type: "event",
-         val: "0.0",
-         orderId: "",
-         promoCode: "",
-         valueCurrency: "USD"
-      });
-      assert(window.k_trackevent.calledWith(params, settings.subdomain));
-    });
-
-    it('should track revenue as `val`', function () {
-      test(kenshoo).track('event', {revenue: "10.2"});
-      var params = constructParams({
-         type: "event",
-         val: "10.2",
-         orderId: "",
-         promoCode: "",
-         valueCurrency: "USD"
-      });
-      assert(window.k_trackevent.calledWith(params, settings.subdomain));
-    });
-
-    it("should default `val` to 0.0 if no 'revenue' is set", function() {
-      test(kenshoo).track('completed order', {
-      });
-
-      assert(window.k_trackevent.calledWith(
-        constructParams({
-          type: "completed order",
-          val: "0.0",
-          orderId: "",
-          promoCode: "",
-          valueCurrency: "USD"
-        }), settings.subdomain));
+      assert(!window.k_trackevent.called);
     });
   });
 });


### PR DESCRIPTION
/cc @reinpk @calvinfo so basically, kenshoo will only track events if you've named them (in the `events` option)
