### PR TITLE
fix intercom company when its a string

### DIFF
--- a/lib/intercom.js
+++ b/lib/intercom.js
@@ -65,7 +65,7 @@ Intercom.prototype.loaded = function () {
 
 /**
  * Load the Intercom library.
- * 
+ *
  * TODO: remove `when()` when integration `.loaded()`
  * behavior is fixed.
  *
@@ -115,7 +115,10 @@ Intercom.prototype.identify = function (identify) {
 
   traits.app_id = this.options.appId;
 
-  // Make sure company traits are carried over (fixes #120).
+  // intercom requires `company` to be an object
+  if (null != traits.company && 'object' != typeof traits.company) traits.company = {};
+
+  // make sure company traits are carried over
   if (!empty(group.traits())) {
     traits.company = traits.company || {};
     defaults(traits.company, group.traits());

--- a/lib/intercom.js
+++ b/lib/intercom.js
@@ -120,8 +120,7 @@ Intercom.prototype.identify = function (identify) {
   if (null != traits.company && !is.object(traits.company)) delete traits.company;
 
   // default it with group traits
-  var groups = group.traits();
-  if (!empty(groups)) {
+  if (!empty(group.traits())) {
     traits.company = traits.company || {};
     defaults(traits.company, group.traits());
   }

--- a/lib/intercom.js
+++ b/lib/intercom.js
@@ -115,21 +115,16 @@ Intercom.prototype.identify = function (identify) {
 
   traits.app_id = this.options.appId;
 
-  // intercom requires `company` to be an object
-  if (is.string(traits.company)) traits.company = { name: traits.company };
+  // intercom requires `company` to be an object. default it with group traits
+  // so that we guarantee an `id` is there, since they require it
   if (null != traits.company && !is.object(traits.company)) delete traits.company;
-
-  // default it with group traits
-  if (!empty(group.traits())) {
-    traits.company = traits.company || {};
-    defaults(traits.company, group.traits());
-  }
+  if (traits.company) defaults(traits.company, group.traits());
 
   // name
   if (name) traits.name = name;
 
   // handle dates
-  if (companyCreated) traits.company.created = companyCreated;
+  if (traits.company && companyCreated) traits.company.created = companyCreated;
   if (created) traits.created = created;
 
   // convert dates

--- a/lib/intercom.js
+++ b/lib/intercom.js
@@ -116,10 +116,12 @@ Intercom.prototype.identify = function (identify) {
   traits.app_id = this.options.appId;
 
   // intercom requires `company` to be an object
-  if (null != traits.company && 'object' != typeof traits.company) traits.company = {};
+  if (is.string(traits.company)) traits.company = { name: traits.company };
+  if (null != traits.company && !is.object(traits.company)) delete traits.company;
 
-  // make sure company traits are carried over
-  if (!empty(group.traits())) {
+  // default it with group traits
+  var groups = group.traits();
+  if (!empty(groups)) {
     traits.company = traits.company || {};
     defaults(traits.company, group.traits());
   }
@@ -134,11 +136,7 @@ Intercom.prototype.identify = function (identify) {
   // convert dates
   traits = convertDates(traits, formatDate);
   traits = alias(traits, { created: 'created_at'});
-
-  // company
-  if (traits.company) {
-    traits.company = alias(traits.company, { created: 'created_at' });
-  }
+  if (traits.company) traits.company = alias(traits.company, { created: 'created_at' });
 
   // handle options
   if (opts.increments) traits.increments = opts.increments;

--- a/test/integrations/intercom.js
+++ b/test/integrations/intercom.js
@@ -239,7 +239,18 @@ describe('Intercom', function () {
         app_id: settings.appId,
         user_id: 'id',
         id: 'id',
-        company: {}
+        company: {
+          name: 'string'
+        }
+      }));
+    });
+
+    it('should not fail when the company trait is a number', function () {
+      test(intercom).identify('id', { company: 97 });
+      assert(window.Intercom.calledWith('boot', {
+        app_id: settings.appId,
+        user_id: 'id',
+        id: 'id'
       }));
     });
 

--- a/test/integrations/intercom.js
+++ b/test/integrations/intercom.js
@@ -238,10 +238,7 @@ describe('Intercom', function () {
       assert(window.Intercom.calledWith('boot', {
         app_id: settings.appId,
         user_id: 'id',
-        id: 'id',
-        company: {
-          name: 'string'
-        }
+        id: 'id'
       }));
     });
 
@@ -254,14 +251,15 @@ describe('Intercom', function () {
       }));
     });
 
-    it('should carry over company traits set in group', function() {
-      analytics.group().traits({foo: 'bar'});
-      test(intercom).identify('id');
+    it('should carry over company traits set in group if a company trait exists', function() {
+      analytics.group().traits({ foo: 'bar' });
+      test(intercom).identify('id', { company: { name: 'name' }});
       assert(window.Intercom.calledWith('boot', {
         app_id: settings.appId,
         user_id: 'id',
         id: 'id',
         company: {
+          name: 'name',
           foo: 'bar'
         }
       }));

--- a/test/integrations/intercom.js
+++ b/test/integrations/intercom.js
@@ -233,6 +233,16 @@ describe('Intercom', function () {
       }));
     });
 
+    it('should not fail when the company trait is a string', function () {
+      test(intercom).identify('id', { company: 'string' });
+      assert(window.Intercom.calledWith('boot', {
+        app_id: settings.appId,
+        user_id: 'id',
+        id: 'id',
+        company: {}
+      }));
+    });
+
     it('should carry over company traits set in group', function() {
       analytics.group().traits({foo: 'bar'});
       test(intercom).identify('id');


### PR DESCRIPTION
The `identify` method in Intercom assumed that company was an object, as Intercom needs, but it could also have been a string or other.

cc @lancejpollard 
