### PR TITLE
mixpanel: delete reserved properties to avoid conflicts

### DIFF
--- a/lib/mixpanel.js
+++ b/lib/mixpanel.js
@@ -177,8 +177,9 @@ Mixpanel.prototype.track = function (track) {
   var props = track.properties();
   var revenue = track.revenue();
 
-  // delete most of mixpanel's reserved properties, so they don't conflict
+  // delete mixpanel's reserved properties, so they don't conflict
   delete props.distinct_id;
+  delete props.ip;
   delete props.mp_name_tag;
   delete props.mp_note;
   delete props.token;

--- a/lib/mixpanel.js
+++ b/lib/mixpanel.js
@@ -177,14 +177,23 @@ Mixpanel.prototype.track = function (track) {
   var props = track.properties();
   var revenue = track.revenue();
 
+  // delete most of mixpanel's reserved properties, so they don't conflict
+  delete props.distinct_id;
+  delete props.mp_name_tag;
+  delete props.mp_note;
+  delete props.token;
+
+  // increment properties in mixpanel people
   if (people && ~indexof(increments, increment)) {
     window.mixpanel.people.increment(track.event());
     window.mixpanel.people.set('Last ' + track.event(), new Date);
   }
 
+  // track the event
   props = dates(props, iso);
   window.mixpanel.track(track.event(), props);
 
+  // track revenue specifically
   if (revenue && people) {
     window.mixpanel.people.track_charge(revenue);
   }
@@ -212,7 +221,7 @@ Mixpanel.prototype.alias = function (alias) {
 
 /**
  * Lowercase the given `arr`.
- * 
+ *
  * @param {Array} arr
  * @return {Array}
  * @api private

--- a/test/integrations/mixpanel.js
+++ b/test/integrations/mixpanel.js
@@ -310,6 +310,16 @@ describe('Mixpanel', function () {
       assert(window.mixpanel.people.increment.calledWith('event'));
       assert(window.mixpanel.people.set.calledWith('Last event', new Date));
     })
+
+    it('should remove mixpanel\'s reserved properties', function(){
+      test(mixpanel).track('event', {
+        distinct_id: 'string',
+        mp_name_tag: 'string',
+        mp_note: 'string',
+        token: 'string'
+      });
+      assert(window.mixpanel.track.calledWith('event', {}));
+    });
   });
 
   describe('#alias', function () {

--- a/test/integrations/mixpanel.js
+++ b/test/integrations/mixpanel.js
@@ -314,6 +314,7 @@ describe('Mixpanel', function () {
     it('should remove mixpanel\'s reserved properties', function(){
       test(mixpanel).track('event', {
         distinct_id: 'string',
+        ip: 'string',
         mp_name_tag: 'string',
         mp_note: 'string',
         token: 'string'


### PR DESCRIPTION
If a user was sending one of Mixpanel's properties we would send it on. This is especially bad for `token` which would mean the event would never hit Mixpanel, or `distinct_id` which would mean that it would be sent as a different user. So this pull request changes it so we delete them.

cc @calvinfo 
