### PR TITLE
Use analytics.user instead of integration options

### DIFF
--- a/lib/appcues.js
+++ b/lib/appcues.js
@@ -21,9 +21,7 @@ var Appcues = exports.Integration = integration('Appcues')
   .readyOnLoad()
   .global('Appcues')
   .global('AppcuesIdentity')
-  .option('appcuesId', '')
-  .option('userId', '')
-  .option('userEmail', '');
+  .option('appcuesId', '');
 
 
 /**
@@ -61,8 +59,8 @@ Appcues.prototype.loaded = function () {
 Appcues.prototype.load = function (callback) {
   var script = load('//d2dubfq97s02eu.cloudfront.net/appcues-bundle.min.js', callback);
   script.setAttribute('data-appcues-id', this.options.appcuesId);
-  script.setAttribute('data-user-id', this.options.userId);
-  script.setAttribute('data-user-email', this.options.userEmail);
+  script.setAttribute('data-user-id', window.analytics.user().id());
+  script.setAttribute('data-user-email', window.analytics.user().id().email());
 };
 
 

--- a/lib/appcues.js
+++ b/lib/appcues.js
@@ -4,11 +4,19 @@ var load = require('load-script');
 
 
 /**
+ * User reference.
+ */
+
+var user;
+
+
+/**
  * Expose plugin.
  */
 
 module.exports = exports = function (analytics) {
   analytics.addIntegration(Appcues);
+  user = analytics.user();
 };
 
 
@@ -59,8 +67,11 @@ Appcues.prototype.loaded = function () {
 Appcues.prototype.load = function (callback) {
   var script = load('//d2dubfq97s02eu.cloudfront.net/appcues-bundle.min.js', callback);
   script.setAttribute('data-appcues-id', this.options.appcuesId);
-  script.setAttribute('data-user-id', window.analytics.user().id());
-  script.setAttribute('data-user-email', window.analytics.user().id().email());
+  script.setAttribute('data-user-id', user.id());
+
+  // Try to assign the user's email as best as we can.
+  var traits = user.traits();
+  script.setAttribute('data-user-email', traits.email || traits.userEmail || traits.user_email);
 };
 
 

--- a/lib/appcues.js
+++ b/lib/appcues.js
@@ -41,9 +41,15 @@ var Appcues = exports.Integration = integration('Appcues')
  */
 
 Appcues.prototype.initialize = function () {
-  this.load(function() {
-    window.Appcues.init();
-  });
+  var traits = user.traits();
+  var email = traits.email || traits.userEmail || traits.user_email;
+
+  // Don't load script if user can't be identified.
+  if (user.id() != null && email) {
+    this.load(function() {
+      window.Appcues.init();
+    });
+  }
 };
 
 
@@ -84,5 +90,15 @@ Appcues.prototype.load = function (callback) {
  */
 
 Appcues.prototype.identify = function (identify) {
-  window.Appcues.identify(identify.traits());
+  var _identify = function() {
+    window.Appcues.identify(identify.traits());
+  }
+  if (!this.loaded()) {
+    this.load(function() {
+      window.Appcues.init();
+      _identify();
+    });
+  } else {
+    _identify();
+  }
 };

--- a/test/integrations/appcues.js
+++ b/test/integrations/appcues.js
@@ -35,9 +35,7 @@ describe('Appcues', function() {
       .readyOnLoad()
       .global('Appcues')
       .global('AppcuesIdentity')
-      .option('appcuesId', '')
-      .option('userId', '')
-      .option('userEmail', '');
+      .option('appcuesId', '');
   });
 
 

--- a/test/integrations/appcues.js
+++ b/test/integrations/appcues.js
@@ -8,9 +8,7 @@ describe('Appcues', function() {
 
   var appcues;
   var settings = {
-    appcuesId: 'test',
-    userId: 'test',
-    userEmail: 'test@testification.com'
+    appcuesId: 'test'
   };
 
   // Disable AMD for these browser tests.
@@ -19,6 +17,7 @@ describe('Appcues', function() {
   beforeEach(function() {
     analytics.use(Appcues);
     appcues = new Appcues.Integration(settings);
+    analytics.user().reset();
     appcues.initialize();
     window.define = undefined;
   });
@@ -44,9 +43,19 @@ describe('Appcues', function() {
       sinon.spy(appcues, 'load');
     });
 
-    it('should call #load', function() {
+    it('should call #load if user is known', function() {
+      analytics.user().id('test');
+      analytics.user().traits({
+        email: 'test@segment.io'
+      });
       appcues.initialize();
       assert(appcues.load.called);
+    });
+
+    it('should not call #load if user is unknown', function() {
+      analytics.user().traits({});
+      appcues.initialize();
+      assert(!appcues.load.called);
     });
   });
 
@@ -80,17 +89,35 @@ describe('Appcues', function() {
 
   describe('#identify', function () {
     beforeEach(function (done) {
-      appcues.initialize();
-      appcues.once('load', function () {
+      // Load the Appcues embed script once.
+      appcues.load();
+      sinon.stub(appcues, 'load', function(callback) { callback() });
+      sinon.stub(appcues, 'loaded', function() { return false });
+      appcues.once('load', function() {
+        window.Appcues.init = sinon.spy();
         window.Appcues.identify = sinon.spy();
-        setTimeout(done, 50);
+        done();
       });
     });
 
+    it('should first try to load the JS if it doesn\'t yet exist', function() {
+      test(appcues).identify('id', {});
+      assert(!appcues.identify.called);
+      assert(appcues.load.called);
+    });
+
+    it('should call Appcues#init and #identify after loading the JS', function() {
+      test(appcues).identify('id', {});
+      assert(window.Appcues.init.called);
+      assert(window.Appcues.identify.calledWith({id: 'id'}));
+    });
+
     it('should proxy traits to Appcues#identify', function() {
+      appcues.loaded.restore()
+      sinon.stub(appcues, 'loaded', function() { return true });
       test(appcues).identify('id', {});
       assert(window.Appcues.identify.calledWith({id: 'id'}));
-    })
+    });
 
   });
 });


### PR DESCRIPTION
This offloads user identity, namely `id` and `email` to analytics.js. Since `email` isn't part of the user prototype, I pick the first one of a few common places it could be.
