### PR TITLE
Retrofit the Drip #track method and add #identify support

### DIFF
--- a/lib/drip/index.js
+++ b/lib/drip/index.js
@@ -79,6 +79,5 @@ Drip.prototype.track = function(track){
  */
 
 Drip.prototype.identify = function (identify) {
-  if (!identify.email()) return; // email is required
   push('identify', identify.traits());
 };

--- a/lib/drip/index.js
+++ b/lib/drip/index.js
@@ -66,9 +66,19 @@ Drip.prototype.load = function(callback){
 
 Drip.prototype.track = function(track){
   var props = track.properties();
-  var cents = Math.round(track.cents());
-  props.action = track.event();
+  var cents = track.cents();
   if (cents) props.value = cents;
   delete props.revenue;
-  push('track', props);
+  push('track', track.event(), props);
+};
+
+/**
+ * Identify.
+ *
+ * @param {Identify} identify
+ */
+
+Drip.prototype.identify = function (identify) {
+  if (!identify.email()) return; // email is required
+  push('identify', identify.traits());
 };

--- a/lib/drip/test.js
+++ b/lib/drip/test.js
@@ -114,11 +114,6 @@ describe('Drip', function(){
       sinon.stub(window._dcq, 'push');
     });
 
-    it('should not send if email is not present', function () {
-      test(drip).identify('id', { name: "Name" });
-      assert(!window._dcq.push.called);
-    });
-
     it('should send identify with traits', function () {
       test(drip)
       .identify('id', { email: 'name@example.com', name: 'Name' })

--- a/lib/drip/test.js
+++ b/lib/drip/test.js
@@ -96,14 +96,34 @@ describe('Drip', function(){
       test(drip)
       .track('event')
       .called(window._dcq.push)
-      .args(['track', { action: 'event' }]);
+      .args(['track', 'event', {}]);
     });
 
     it('should convert and alias revenue', function(){
       test(drip)
-      .track('event', { revenue: 9.999 })
+      .track('event', { revenue: '$9.99' })
       .called(window._dcq.push)
-      .args(['track', { action: 'event', value: 1000 }]);
+      .args(['track', 'event', { value: 999 }]);
+    });
+  });
+
+  describe('#identify', function () {
+    beforeEach(function () {
+      sinon.stub(drip, 'load');
+      drip.initialize();
+      sinon.stub(window._dcq, 'push');
+    });
+
+    it('should not send if email is not present', function () {
+      test(drip).identify('id', { name: "Name" });
+      assert(!window._dcq.push.called);
+    });
+
+    it('should send identify with traits', function () {
+      test(drip)
+      .identify('id', { email: 'name@example.com', name: 'Name' })
+      .called(window._dcq.push)
+      .args(['identify', { email: 'name@example.com', name: 'Name' }]);
     });
   });
 


### PR DESCRIPTION
We recently made some changes/enhancements to our JavaScript API:
https://www.getdrip.com/docs/js-api

Namely, we changed the argument structure of our `#track` method to more closely follow standard patterns (although we are maintaining backwards compatibility) and we added support for the `#identify` method. These changes are reflected here.

**Note**: I think my tests are correct, but I cannot seem to get the test suite to pass. I'm getting this error all over the place. Any guidance on this?

```
Error: Don't override the "loaded" method from the base integration
      at :19
      at Tester (:71)
      at Tester (:57)
      at http://localhost:4202/test/integrations/drip.js:118
      at http://localhost:4202/test/mocha.js:4212
      at http://localhost:4202/test/mocha.js:4584
      at http://localhost:4202/test/mocha.js:4643
      at next (http://localhost:4202/test/mocha.js:4510)
      at http://localhost:4202/test/mocha.js:4519
      at next (http://localhost:4202/test/mocha.js:4463)
      at http://localhost:4202/test/mocha.js:4482
      at http://localhost:4202/test/mocha.js:4214
      at next (http://localhost:4202/test/mocha.js:4483)
      at http://localhost:4202/test/mocha.js:4487
      at timeslice (http://localhost:4202/test/mocha.js:5480)
```
