### PR TITLE
adroll: add `.page` and make `.track` only send revenue when conversion events are defined

### DIFF
--- a/lib/adroll.js
+++ b/lib/adroll.js
@@ -1,8 +1,11 @@
 
-var integration = require('integration');
-var is = require('is');
-var load = require('load-script');
+/**
+ * Module dependencies.
+ */
 
+var integration = require('integration');
+var load = require('load-script');
+var is = require('is');
 
 /**
  * User reference.
@@ -20,11 +23,10 @@ var has = Object.prototype.hasOwnProperty;
  * Expose plugin.
  */
 
-module.exports = exports = function (analytics) {
+module.exports = exports = function(analytics){
   analytics.addIntegration(AdRoll);
   user = analytics.user(); // store for later
 };
-
 
 /**
  * Expose `AdRoll` integration.
@@ -41,7 +43,6 @@ var AdRoll = exports.Integration = integration('AdRoll')
   .option('advId', '')
   .option('pixId', '');
 
-
 /**
  * Initialize.
  *
@@ -51,13 +52,12 @@ var AdRoll = exports.Integration = integration('AdRoll')
  * @param {Object} page
  */
 
-AdRoll.prototype.initialize = function (page) {
+AdRoll.prototype.initialize = function(page){
   window.adroll_adv_id = this.options.advId;
   window.adroll_pix_id = this.options.pixId;
   window.__adroll_loaded = true;
   this.load();
 };
-
 
 /**
  * Loaded?
@@ -65,22 +65,34 @@ AdRoll.prototype.initialize = function (page) {
  * @return {Boolean}
  */
 
-AdRoll.prototype.loaded = function () {
+AdRoll.prototype.loaded = function(){
   return window.__adroll;
 };
-
 
 /**
  * Load the AdRoll library.
  *
- * @param {Function} callback
+ * @param {Function} fn
  */
 
-AdRoll.prototype.load = function (callback) {
+AdRoll.prototype.load = function(fn){
   load({
     http: 'http://a.adroll.com/j/roundtrip.js',
     https: 'https://s.adroll.com/j/roundtrip.js'
-  }, callback);
+  }, fn);
+};
+
+/**
+ * Page.
+ *
+ * http://support.adroll.com/segmenting-clicks/
+ *
+ * @param {Page} page
+ */
+
+AdRoll.prototype.page = function(page){
+  var name = page.fullName();
+  this.track(page.track(name));
 };
 
 /**
@@ -91,14 +103,19 @@ AdRoll.prototype.load = function (callback) {
 
 AdRoll.prototype.track = function(track){
   var events = this.options.events;
-  var total = track.revenue();
   var event = track.event();
-  if (has.call(events, event)) event = events[event];
-  var data = {
-    adroll_conversion_value_in_dollars: total || 0,
-    order_id: track.orderId() || 0,
-    adroll_segments: event
-  };
+  var data = {};
   if (user.id()) data.user_id = user.id();
+
+  if (has.call(events, event)) {
+    event = events[event];
+    var total = track.revenue() || track.total() || 0;
+    var orderId = track.orderId() || 0;
+    data.adroll_conversion_value_in_dollars = total;
+    data.order_id = orderId;
+  }
+
+  data.adroll_segments = event;
+
   window.__adroll.record_user(data);
 };

--- a/test/integrations/adroll.js
+++ b/test/integrations/adroll.js
@@ -1,5 +1,5 @@
 
-describe('AdRoll', function () {
+describe('AdRoll', function(){
 
   var AdRoll = require('integrations/lib/adroll');
   var analytics = require('analytics');
@@ -14,18 +14,18 @@ describe('AdRoll', function () {
     pixId: 'V7TLXL5WWBA5NOU5MOJQW4'
   };
 
-  beforeEach(function () {
+  beforeEach(function(){
     analytics.use(AdRoll);
     adroll = new AdRoll.Integration(settings);
     adroll.initialize(); // noop
   });
 
-  afterEach(function () {
+  afterEach(function(){
     adroll.reset();
     analytics.user().reset();
   });
 
-  it('should have the right settings', function () {
+  it('should have the right settings', function(){
     test(adroll)
       .name('AdRoll')
       .assumesPageview()
@@ -38,58 +38,58 @@ describe('AdRoll', function () {
       .option('pixId', '');
   });
 
-  describe('#initialize', function () {
-    beforeEach(function () {
+  describe('#initialize', function(){
+    beforeEach(function(){
       adroll.load = sinon.spy();
     });
 
-    it('should initialize the adroll variables', function () {
+    it('should initialize the adroll variables', function(){
       adroll.initialize();
       assert(window.adroll_adv_id === settings.advId);
       assert(window.adroll_pix_id === settings.pixId);
     });
 
-    it('should not set a user id', function () {
+    it('should not set a user id', function(){
       analytics.user().identify('id');
       adroll.initialize();
       assert(window.adroll_custom_data == null);
     });
 
-    it('should set window.__adroll_loaded', function () {
+    it('should set window.__adroll_loaded', function(){
       adroll.initialize();
       assert(window.__adroll_loaded === true);
     });
 
-    it('should call #load', function () {
+    it('should call #load', function(){
       adroll.initialize();
       assert(adroll.load.called);
     });
   });
 
-  describe('#loaded', function () {
-    after(function () {
+  describe('#loaded', function(){
+    after(function(){
       window.__adroll = undefined;
     });
 
-    it('should test window.__adroll', function () {
+    it('should test window.__adroll', function(){
       assert(!adroll.loaded());
       window.__adroll = {};
       assert(adroll.loaded());
     });
   });
 
-  describe('#load', function () {
-    beforeEach(function () {
+  describe('#load', function(){
+    beforeEach(function(){
       sinon.stub(adroll, 'load');
       adroll.initialize();
       adroll.load.restore();
     });
 
-    it('should change loaded state', function (done) {
+    it('should change loaded state', function(done){
       assert(!adroll.loaded());
-      adroll.load(function (err) {
+      adroll.load(function(err){
         if (err) return done(err);
-        setTimeout(function () {
+        setTimeout(function(){
           assert(adroll.loaded());
           done();
         }, 1000);
@@ -97,60 +97,105 @@ describe('AdRoll', function () {
     });
   });
 
+  describe('#page', function(){
+    beforeEach(function(done){
+      adroll.on('ready', done);
+      adroll.initialize();
+      window.__adroll.record_user = sinon.spy();
+    });
+
+    it('should track page view with fullName', function(){
+      test(adroll).page('Category', 'Name');
+      assert(window.__adroll.record_user.calledWith({
+        adroll_segments: 'Viewed Category Name Page'
+      }));
+    });
+
+    it('should track unnamed/categorized page', function(){
+      test(adroll).page();
+      assert(window.__adroll.record_user.calledWith({
+        adroll_segments: 'Loaded a Page'
+      }));
+    });
+
+    it('should track unnamed page', function(){
+      test(adroll).page('Category');
+      assert(window.__adroll.record_user.calledWith({
+        adroll_segments: 'Loaded a Page'
+      }));
+    });
+
+    it('should track uncategorized page', function(){
+      test(adroll).page(null, 'Name');
+      assert(window.__adroll.record_user.calledWith({
+        adroll_segments: 'Viewed Name Page'
+      }));
+    });
+  });
+
   describe('#track', function(){
     beforeEach(function(){
       window.__adroll.record_user = sinon.spy();
-    })
+    });
 
-    it('should send events', function(){
-      test(adroll).track('event', {});
-      assert(window.__adroll.record_user.calledWith({
-        adroll_segments: 'event',
-        adroll_conversion_value_in_dollars: 0,
-        order_id: 0
-      }));
-    })
+    describe('event not in events', function(){
+      it('should send events with only adroll_segments', function(){
+        test(adroll).track('event', {});
+        assert(window.__adroll.record_user.calledWith({
+          adroll_segments: 'event'
+        }));
+      });
 
-    it('should track Completed Order', function(){
-      adroll.options.events = { event: 'segment' };
-      test(adroll).track('Completed Order', { total: 1.99, orderId: 1 });
-      assert(window.__adroll.record_user.calledWith({
-        adroll_segments: 'Completed Order',
-        adroll_conversion_value_in_dollars: 1.99,
-        order_id: 1
-      }));
-    })
+      it('should send events without revenue and order id', function(){
+        test(adroll).track('event', { revenue: 3.99 });
+        assert(window.__adroll.record_user.calledWith({
+          adroll_segments: 'event'
+        }));
+      });
 
-    it('should pass .revenue as conversion value', function(){
-      test(adroll).track('purchase', { revenue: 2.99 });
-      assert(window.__adroll.record_user.calledWith({
-        adroll_segments: 'purchase',
-        adroll_conversion_value_in_dollars: 2.99,
-        order_id: 0
-      }));
-    })
+      it('should pass user id in', function(){
+        analytics.user().identify('id');
+        test(adroll).track('event', { revenue: 3.99 });
+        assert(window.__adroll.record_user.calledWith({
+          adroll_segments: 'event',
+          user_id: 'id'
+        }));
+      });
+    });
 
-    it('should respect .events option', function(){
-      adroll.options.events = { event: 'segment' };
-      test(adroll).track('event', { revenue: 3.99 });
-      assert(window.__adroll.record_user.calledWith({
-        adroll_segments: 'segment',
-        adroll_conversion_value_in_dollars: 3.99,
-        order_id: 0
-      }));
-    })
+    describe('event in events', function(){
+      beforeEach(function(){
+        adroll.options.events = { event: 'segment' };
+      });
 
-    it('should include the user_id when available', function(){
-      analytics.user().identify('id');
-      adroll.options.events = { event: 'segment' };
-      test(adroll).track('event', { revenue: 3.99 });
-      assert(window.__adroll.record_user.calledWith({
-        adroll_segments: 'segment',
-        adroll_conversion_value_in_dollars: 3.99,
-        order_id: 0,
-        user_id: 'id'
-      }));
-    })
-  })
+      it('should pass in revenue and order id', function(){
+        test(adroll).track('event', { total: 1.99, orderId: 1 });
+        assert(window.__adroll.record_user.calledWith({
+          adroll_segments: 'segment',
+          adroll_conversion_value_in_dollars: 1.99,
+          order_id: 1
+        }));
+      });
 
+      it('should pass .revenue as conversion value', function(){
+        test(adroll).track('event', { revenue: 2.99 });
+        assert(window.__adroll.record_user.calledWith({
+          adroll_segments: 'segment',
+          adroll_conversion_value_in_dollars: 2.99,
+          order_id: 0
+        }));
+      });
+
+      it('should include the user_id when available', function(){
+        analytics.user().identify('id');
+        test(adroll).track('event', { revenue: 3.99 });
+        assert(window.__adroll.record_user.calledWith({
+          adroll_segments: 'segment',
+          adroll_conversion_value_in_dollars: 3.99,
+          order_id: 0,
+          user_id: 'id'
+        }));
+      });
+    });
+  });
 });


### PR DESCRIPTION
- It only sends the `adroll_conversion_value_in_dollars` and `order_id` if a conversion event in the `events` mapping is defined. In that case, it also renames the event to the value in the `events` mapping.
- If a `user_id` exists, it attaches it to the data.
- In all `.track` calls, it makes the call to `__adroll.record_user` (just different params described above, based on if the event is in the `events` mapping)
- Added the `.page` call which just uses the `page.fullName()` for the name of the track event.

/cc @calvinfo 
