### PR TITLE
facebook-ads: add support for custom events

### DIFF
--- a/lib/facebook-ads.js
+++ b/lib/facebook-ads.js
@@ -1,7 +1,11 @@
 
-var load = require('load-script');
-var integration = require('integration');
+/**
+ * Module dependencies.
+ */
+
 var push = require('global-queue')('_fbq');
+var integration = require('integration');
+var load = require('load-script');
 
 /**
  * Expose plugin
@@ -64,6 +68,8 @@ Facebook.prototype.loaded = function(){
 /**
  * Track.
  *
+ * https://developers.facebook.com/docs/reference/ads-api/custom-audience-website-faq/#fbpixel
+ *
  * @param {Track} track
  */
 
@@ -72,9 +78,14 @@ Facebook.prototype.track = function(track){
   var traits = track.traits();
   var event = track.event();
   var revenue = track.revenue() || 0;
-  if (!has.call(events, event)) return;
-  push('track', events[event], {
-    value: String(revenue.toFixed(2)),
-    currency: this.options.currency
-  });
+  var data = track.properties();
+  if (has.call(events, event)) {
+    // conversion flow
+    event = events[event];
+    data = {
+      value: String(revenue.toFixed(2)),
+      currency: this.options.currency
+    };
+  }
+  push('track', event, data);
 };

--- a/test/integrations/facebook-ads.js
+++ b/test/integrations/facebook-ads.js
@@ -20,7 +20,7 @@ describe('Facebook Ads', function(){
     analytics.use(Facebook);
     facebook = new Facebook.Integration(settings);
     facebook.initialize();
-  })
+  });
 
   it('should have the correct settings', function(){
     test(facebook)
@@ -28,7 +28,7 @@ describe('Facebook Ads', function(){
       .readyOnInitialize()
       .option('currency', 'USD')
       .option('events', {});
-  })
+  });
 
   it('should load', function(done){
     window._fbq = [];
@@ -37,35 +37,36 @@ describe('Facebook Ads', function(){
       assert(facebook.loaded());
       done();
     });
-  })
+  });
 
   describe('#track', function(){
     beforeEach(function(){
       sinon.stub(window._fbq, 'push');
-    })
+    });
 
     afterEach(function(){
       window._fbq = [];
-    })
+    });
 
-    it('should not send if event is not define', function(){
-      test(facebook).track('toString', {});
-      assert(!_fbq.push.called);
-    })
+    it('should send custom event even if event is not defined', function(){
+      test(facebook)
+        .track('event', { x: 10 })
+        .called(_fbq.push)
+        .with([ 'track', 'event', { x: 10 } ]);
+    });
 
     it('should send event if found', function(){
       test(facebook)
         .track('signup', {})
         .called(_fbq.push)
         .with([ 'track', 0, { currency: 'USD', value: '0.00' } ]);
-    })
+    });
 
     it('should send revenue', function(){
       test(facebook)
         .track('login', { revenue: '$50' })
         .called(_fbq.push)
         .with([ 'track', 1, { value: '50.00', currency: 'USD' } ]);
-    })
-  })
-
-})
+    });
+  });
+});


### PR DESCRIPTION
with this `.track` always sends an event:
- if it's in the `events` map, then the event name gets translated and it sends the 2 special conversion event properties (currency and value)
- otherwise, it just sends along the original event name and any properties you might have passed along.

/cc @calvinfo 
