### PR TITLE
refactor tests to dsl

### DIFF
--- a/lib/adroll/test.js
+++ b/lib/adroll/test.js
@@ -1,14 +1,13 @@
 
+var tester = require('analytics.js-integration-tester');
+var analytics = require('analytics.js');
+var assert = require('assert');
+var equal = require('equals');
+var AdRoll = require('./');
+
 describe('AdRoll', function(){
-
-  var test = require('analytics.js-integration-tester');
-  var analytics = require('analytics.js');
-  var assert = require('assert');
-  var equal = require('equals');
-  var sinon = require('sinon');
-  var AdRoll = require('./');
-
   var adroll;
+  var test;
   var settings = {
     advId: 'LYFRCUIPPZCCTOBGRH7G32',
     pixId: 'V7TLXL5WWBA5NOU5MOJQW4'
@@ -17,16 +16,16 @@ describe('AdRoll', function(){
   beforeEach(function(){
     analytics.use(AdRoll);
     adroll = new AdRoll.Integration(settings);
-    adroll.initialize(); // noop
+    test = tester(adroll);
   });
 
   afterEach(function(){
-    adroll.reset();
+    test.reset();
     analytics.user().reset();
   });
 
   it('should have the right settings', function(){
-    test(adroll)
+    test
       .name('AdRoll')
       .assumesPageview()
       .readyOnLoad()
@@ -39,58 +38,59 @@ describe('AdRoll', function(){
   });
 
   describe('#initialize', function(){
-    beforeEach(function(){
-      adroll.load = sinon.spy();
-    });
-
     it('should initialize the adroll variables', function(){
-      adroll.initialize();
-      assert(window.adroll_adv_id === settings.advId);
-      assert(window.adroll_pix_id === settings.pixId);
+      test
+        .initialize()
+        .equal(window.adroll_adv_id, settings.advId)
+        .equal(window.adroll_pix_id, settings.pixId);
     });
 
     it('should not set a user id', function(){
+      // XXX: should we refactor this too?
       analytics.user().identify('id');
-      adroll.initialize();
-      assert(window.adroll_custom_data == null);
+      test
+        .initialize()
+        .equal(window.adroll_custom_data, null);
     });
 
     it('should set window.__adroll_loaded', function(){
-      adroll.initialize();
-      assert(window.__adroll_loaded === true);
+      test
+        .initialize()
+        .equal(window.__adroll_loaded, true);
     });
 
     it('should call #load', function(){
-      adroll.initialize();
-      assert(adroll.load.called);
+      test
+        .initialize()
+        .called(adroll.load);
     });
   });
 
   describe('#loaded', function(){
     after(function(){
+      // XXX: this seems like it should be handled in maybe a global `test.reset()`?
       window.__adroll = undefined;
     });
 
     it('should test window.__adroll', function(){
-      assert(!adroll.loaded());
+      assert(!test.loaded());
       window.__adroll = {};
-      assert(adroll.loaded());
+      assert(test.loaded());
     });
   });
 
   describe('#load', function(){
     beforeEach(function(){
-      sinon.stub(adroll, 'load');
-      adroll.initialize();
-      adroll.load.restore();
+      test.initialize();
+      test.load.restore();
     });
 
     it('should change loaded state', function(done){
-      assert(!adroll.loaded());
-      adroll.load(function(err){
+      assert(!test.loaded());
+      test.load(function(err){
         if (err) return done(err);
         setTimeout(function(){
-          assert(adroll.loaded());
+          assert(test.loaded());
           done();
         }, 1000);
       });
@@ -98,103 +98,114 @@ describe('AdRoll', function(){
   });
 
   describe('#page', function(){
-    beforeEach(function(done){
-      adroll.on('ready', done);
-      adroll.initialize();
-      window.__adroll.record_user = sinon.spy();
+    beforeEach(function(){
+      test
+        .initialize()
+        .spy(window.__adroll, 'record_user');
     });
 
     it('should track page view with fullName', function(){
-      test(adroll).page('Category', 'Name');
-      assert(window.__adroll.record_user.calledWith({
-        adroll_segments: 'Viewed Category Name Page'
-      }));
+      test
+        .page('Category', 'Name')
+        .called(window.__adroll.record_user, {
+          adroll_segments: 'Viewed Category Name Page'
+        });
     });
 
     it('should track unnamed/categorized page', function(){
-      test(adroll).page();
-      assert(window.__adroll.record_user.calledWith({
-        adroll_segments: 'Loaded a Page'
-      }));
+      test
+        .page()
+        .called(window.__adroll.record_user, {
+          adroll_segments: 'Loaded a Page'
+        });
     });
 
     it('should track unnamed page', function(){
-      test(adroll).page('Category');
-      assert(window.__adroll.record_user.calledWith({
-        adroll_segments: 'Loaded a Page'
-      }));
+      test
+        .page('Category')
+        .called(window.__adroll.record_user, {
+          adroll_segments: 'Loaded a Page'
+        });
     });
 
     it('should track uncategorized page', function(){
-      test(adroll).page(null, 'Name');
-      assert(window.__adroll.record_user.calledWith({
-        adroll_segments: 'Viewed Name Page'
-      }));
+      test
+        .page(null, 'Name')
+        .called(window.__adroll.record_user, {
+          adroll_segments: 'Viewed Name Page'
+        });
     });
   });
 
   describe('#track', function(){
     beforeEach(function(){
-      window.__adroll.record_user = sinon.spy();
+      test
+        .spy(window.__adroll, 'record_user');
     });
 
     describe('event not in events', function(){
       it('should send events with only adroll_segments', function(){
-        test(adroll).track('event', {});
-        assert(window.__adroll.record_user.calledWith({
-          adroll_segments: 'event'
-        }));
+        test
+          .track('event', {})
+          .called(window.__adroll.record_user, {
+            adroll_segments: 'event'
+          });
       });
 
       it('should send events without revenue and order id', function(){
-        test(adroll).track('event', { revenue: 3.99 });
-        assert(window.__adroll.record_user.calledWith({
-          adroll_segments: 'event'
-        }));
+        test
+          .track('event', { revenue: 3.99 })
+          .called(window.__adroll.record_user, {
+            adroll_segments: 'event'
+          });
       });
 
       it('should pass user id in', function(){
         analytics.user().identify('id');
-        test(adroll).track('event', { revenue: 3.99 });
-        assert(window.__adroll.record_user.calledWith({
-          adroll_segments: 'event',
-          user_id: 'id'
-        }));
+        test
+          .track('event', { revenue: 3.99 })
+          .called(window.__adroll.record_user, {
+            adroll_segments: 'event',
+            user_id: 'id'
+          });
       });
     });
 
     describe('event in events', function(){
       beforeEach(function(){
-        adroll.options.events = { event: 'segment' };
+        test.options.events = { event: 'segment' };
       });
 
       it('should pass in revenue and order id', function(){
-        test(adroll).track('event', { total: 1.99, orderId: 1 });
-        assert(window.__adroll.record_user.calledWith({
-          adroll_segments: 'segment',
-          adroll_conversion_value_in_dollars: 1.99,
-          order_id: 1
-        }));
+        test
+          .track('event', { total: 1.99, orderId: 1 })
+          .called(window.__adroll.record_user, {
+            adroll_segments: 'segment',
+            adroll_conversion_value_in_dollars: 1.99,
+            order_id: 1
+          });
       });
 
       it('should pass .revenue as conversion value', function(){
-        test(adroll).track('event', { revenue: 2.99 });
-        assert(window.__adroll.record_user.calledWith({
-          adroll_segments: 'segment',
-          adroll_conversion_value_in_dollars: 2.99,
-          order_id: 0
-        }));
+        test
+          .track('event', { revenue: 2.99 })
+          .called(window.__adroll.record_user, {
+            adroll_segments: 'segment',
+            adroll_conversion_value_in_dollars: 2.99,
+            order_id: 0
+          });
       });
 
       it('should include the user_id when available', function(){
         analytics.user().identify('id');
-        test(adroll).track('event', { revenue: 3.99 });
-        assert(window.__adroll.record_user.calledWith({
-          adroll_segments: 'segment',
-          adroll_conversion_value_in_dollars: 3.99,
-          order_id: 0,
-          user_id: 'id'
-        }));
+        test
+          .track('event', { revenue: 3.99 })
+          .called(window.__adroll.record_user, {
+            adroll_segments: 'segment',
+            adroll_conversion_value_in_dollars: 3.99,
+            order_id: 0,
+            user_id: 'id'
+          });
       });
     });
   });

--- a/lib/adwords/test.js
+++ b/lib/adwords/test.js
@@ -1,12 +1,12 @@
 
+var tester = require('analytics.js-integration-tester');
+var analytics = require('analytics.js');
+var AdWords = require('./index');
+var assert = require('assert');
+
 describe('AdWords', function(){
-
-  var AdWords = require('./index')
-  var test = require('analytics.js-integration-tester');
-  var analytics = require('analytics.js');
-  var assert = require('assert');
-  var sinon = require('sinon');
-
+  var adwords;
+  var test;
   var settings = {
     conversionId: 978352801,
     events: {
@@ -19,22 +19,27 @@ describe('AdWords', function(){
   beforeEach(function(){
     analytics.use(AdWords);
     adwords = new AdWords.Integration(settings);
-  })
+    test = tester(adwords);
+  });
 
   it('should have the correct settings', function(){
-    test(adwords)
+    test
       .name('AdWords')
       .readyOnLoad()
       .option('conversionId', '')
       .option('remarketing', false)
       .option('events', {});
-  })
+  });
 
   describe('#load', function(){
+    beforeEach(function(){
+      test.load.restore();
+    });
+
     it('should load', function(done){
-      adwords.load(function(){ done(); });
-    })
-  })
+      test.load(done);
+    });
+  });
 
   describe('#conversion', function(){
     beforeEach(function(){
@@ -62,8 +67,8 @@ describe('AdWords', function(){
 
         done();
       });
-    })
-  })
+    });
+  });
 
   describe('#page', function(){
     beforeEach(function(done){
@@ -71,48 +76,53 @@ describe('AdWords', function(){
       sinon.spy(adwords, 'remarketing');
       sinon.spy(adwords, 'globalize');
       adwords.initialize();
-    })
+    });
 
     it('should not load remarketing if option is not on', function(){
-      test(adwords).page();
-      assert(!adwords.remarketing.called);
-    })
+      test
+        .page()
+        .called(adwords.remarketing);
+    });
 
     it('should load remarketing if option is on', function(){
       adwords.options.remarketing = true;
-      test(adwords).page();
-      assert(adwords.remarketing.calledOnce);
-    })
-  })
+      test
+        .page()
+        .calledOnce(adwords.remarketing);
+    });
+  });
 
   describe('#track', function(){
     beforeEach(function(done){
       adwords.on('ready', done);
       sinon.spy(adwords, 'conversion');
       adwords.initialize();
-    })
+    });
 
     it('should not send if event is not defined', function(){
-      test(adwords).track('toString', {});
-      assert(!adwords.conversion.called);
-    })
+      test
+        .track('toString', {})
+        .called(adwords.conversion);
+    });
 
     it('should send event if its defined', function(){
-      test(adwords).track('signup', {});
-      assert(adwords.conversion.calledWith({
-        conversionId: adwords.options.conversionId,
-        label: adwords.options.events.signup,
-        value: 0,
-      }))
-    })
+      test
+        .track('signup', {})
+        .called(adwords.conversion, {
+          conversionId: adwords.options.conversionId,
+          label: adwords.options.events.signup,
+          value: 0
+        });
+    });
 
     it('should send revenue', function(){
-      test(adwords).track('login', { revenue: 90 });
-      assert(adwords.conversion.calledWith({
-        conversionId: adwords.options.conversionId,
-        label: adwords.options.events.login,
-        value: 90
-      }));
+      test
+        .track('login', { revenue: 90 })
+        .called(adwords.conversion, {
+          conversionId: adwords.options.conversionId,
+          label: adwords.options.events.login,
+          value: 90
+        });
     })
   })
 })

--- a/lib/alexa/test.js
+++ b/lib/alexa/test.js
@@ -1,14 +1,13 @@
 
+var tester = require('analytics.js-integration-tester');
+var analytics = require('analytics.js');
+var assert = require('assert');
+var Alexa = require('./index')
+var equal = require('equals');
+
 describe('Alexa', function(){
-
-  var analytics = require('analytics.js');
-  var assert = require('assert');
-  var Alexa = require('./index')
-  var equal = require('equals');
-  var sinon = require('sinon');
-  var test = require('analytics.js-integration-tester');
-
   var alexa;
+  var test;
   var settings = {
     account: 'h5Gaj1a4ZP000h',
     domain: 'mydomain.com',
@@ -18,7 +17,7 @@ describe('Alexa', function(){
   beforeEach(function(){
     analytics.use(Alexa);
     alexa = new Alexa.Integration(settings);
-    alexa.initialize(); // noop
+    test = tester(alexa).stub('load');
   });
 
   afterEach(function(){
@@ -26,7 +25,7 @@ describe('Alexa', function(){
   });
 
   it('should have the right settings', function(){
-    test(alexa)
+    test
       .name('Alexa')
       .assumesPageview()
       .readyOnLoad()
@@ -38,42 +37,39 @@ describe('Alexa', function(){
 
   describe('#initialize', function(){
     beforeEach(function(){
-      alexa.load = sinon.spy();
+      test.initialize();
     });
 
     it('should create window._atrk_opts', function(){
-      alexa.initialize();
-      assert(equal(window._atrk_opts, {
+      test.deepEqual(window._atrk_opts, {
         atrk_acct: settings.account,
         domain: settings.domain,
         dynamic: settings.dynamic
-      }));
+      });
     });
 
     it('should call #load', function(){
-      alexa.initialize();
-      assert(alexa.load.called);
+      test.called(test.load);
     });
   });
 
   describe('#loaded', function(){
     it('should test window.atrk', function(){
-      assert(!alexa.loaded());
+      assert(!test.loaded());
       window.atrk = function(){};
-      assert(alexa.loaded());
+      assert(test.loaded());
       window.atrk = null;
     });
   });
 
   describe('#load', function(){
-    it('should change loaded state', function (done) {
-      assert(!alexa.loaded());
-      alexa.load(function (err) {
+    it('should change loaded state', function(done){
+      assert(!test.loaded());
+      test.load(function(err){
         if (err) return done(err);
         assert(alexa.loaded());
         done();
       });
     });
   });
-
 });

--- a/lib/mixpanel/test.js
+++ b/lib/mixpanel/test.js
@@ -1,16 +1,15 @@
 
+var tester = require('analytics.js-integration-tester');
+var analytics = require('analytics.js');
+var iso = require('to-iso-string');
+var Mixpanel = require('./index');
+var assert = require('assert');
+var equal = require('equals');
+var sinon = require('sinon');
+
 describe('Mixpanel', function(){
-
-  var analytics = require('analytics.js');
-  var assert = require('assert');
-  var iso = require('to-iso-string');
-  var Mixpanel = require('./index')
-  var sinon = require('sinon');
-  var test = require('analytics.js-integration-tester');
-  var equal = require('equals');
-  var iso = require('to-iso-string');
-
   var mixpanel;
+  var test;
   var settings = {
     token: 'x'
   };
@@ -18,14 +17,15 @@ describe('Mixpanel', function(){
   beforeEach(function(){
     analytics.use(Mixpanel);
     mixpanel = new Mixpanel.Integration(settings);
+    test = tester(mixpanel);
   });
 
   afterEach(function(){
-    mixpanel.reset();
+    test.reset();
   });
 
   it('should have the right settings', function(){
-    test(mixpanel)
+    test
       .name('Mixpanel')
       .readyOnLoad()
       .global('mixpanel')
@@ -39,49 +39,46 @@ describe('Mixpanel', function(){
   });
 
   describe('#initialize', function(){
-    beforeEach(function(){
-      mixpanel.load = sinon.spy();
-    });
-
     it('should create window.mixpanel', function(){
       assert(!window.mixpanel);
-      mixpanel.initialize();
+      test.initialize();
       assert(window.mixpanel);
     });
 
     it('should call #load', function(){
-      mixpanel.initialize();
-      assert(mixpanel.load.called);
+      test
+        .initialize()
+        .called(mixpanel.load);
     });
 
     it('should lowercase increments', function(){
-      mixpanel.options.increments = ['A', 'b', 'c_'];
-      mixpanel.initialize();
-      assert(equal(mixpanel.options.increments, ['a', 'b', 'c_']));
-    })
+      test
+        .option('increments', ['A', 'b', 'c_'])
+        .initialize()
+        .deepEqual(mixpanel.options.increments, ['a', 'b', 'c_']);
+    });
   });
 
   describe('#loaded', function(){
     it('should test window.mixpanel.config', function(){
       window.mixpanel = {};
-      assert(!mixpanel.loaded());
+      assert(!test.loaded());
       window.mixpanel.config = {};
-      assert(mixpanel.loaded());
+      assert(test.loaded());
     });
   });
 
   describe('#load', function(){
     beforeEach(function(){
-      sinon.stub(mixpanel, 'load');
-      mixpanel.initialize();
-      mixpanel.load.restore();
+      test.initialize();
+      test.load.restore();
     });
 
-    it('should change loaded state', function (done) {
-      assert(!mixpanel.loaded());
-      mixpanel.load(function (err) {
+    it('should change loaded state', function(done){
+      assert(!test.loaded());
+      test.load(function(err){
         if (err) return done(err);
-        assert(mixpanel.loaded());
+        assert(test.loaded());
         done();
       });
     });
@@ -89,255 +86,271 @@ describe('Mixpanel', function(){
 
   describe('#page', function(){
     beforeEach(function(){
-      mixpanel.initialize();
-      window.mixpanel.track = sinon.spy();
+      test
+        .initialize()
+        .spy(window.mixpanel, 'track');
     });
 
     it('should not track anonymous pages by default', function(){
-      test(mixpanel).page();
-      assert(!window.mixpanel.track.called);
+      test
+        .page()
+        .didntCall(window.mixpanel.track);
     });
 
     it('should track anonymous pages when the option is on', function(){
-      mixpanel.options.trackAllPages = true;
-      test(mixpanel).page();
-      assert(window.mixpanel.track.calledWith('Loaded a Page'));
+      test
+        .option('trackAllPages', true)
+        .page()
+        .called(window.mixpanel.track, 'Loaded a Page');
     });
 
     it('should track named pages by default', function(){
-      test(mixpanel).page(null, 'Name');
-      assert(window.mixpanel.track.calledWith('Viewed Name Page'));
+      test
+        .page(null, 'Name')
+        .called(window.mixpanel.track, 'Viewed Name Page');
     });
 
     it('should track named pages with categories', function(){
-      test(mixpanel).page('Category', 'Name');
-      assert(window.mixpanel.track.calledWith('Viewed Category Name Page'));
+      test
+        .page('Category', 'Name')
+        .called(window.mixpanel.track, 'Viewed Category Name Page');
     });
 
     it('should track categorized pages by default', function(){
-      test(mixpanel).page('Category', 'Name');
-      assert(window.mixpanel.track.calledWith('Viewed Category Page'));
+      test
+        .page('Category', 'Name')
+        .called(window.mixpanel.track, 'Viewed Category Page');
     });
 
     it('should not track category pages when the option is off', function(){
-      mixpanel.options.trackNamedPages = false;
-      mixpanel.options.trackCategorizedPages = false;
-      test(mixpanel).page(null, 'Name');
-      test(mixpanel).page('Category', 'Name');
-      assert(!window.mixpanel.track.called);
+      test
+        .option('trackNamedPages', false)
+        .option('trackCategorizedPages', false);
+        .page(null, 'Name')
+        .page('Category', 'Name')
+        .didntCall(window.mixpanel.track);
     });
   });
 
   describe('#identify', function(){
     beforeEach(function(){
-      mixpanel.initialize();
-      window.mixpanel.identify = sinon.spy();
-      window.mixpanel.register = sinon.spy();
-      window.mixpanel.name_tag = sinon.spy();
-      window.mixpanel.people.set = sinon.spy();
+      test
+        .initialize()
+        .spy(window.mixpanel, 'identify')
+        .spy(window.mixpanel, 'register')
+        .spy(window.mixpanel, 'name_tag')
+        .spy(window.mixpanel, 'people.set');
     });
 
     it('should send an id', function(){
-      test(mixpanel)
+      test
         .identify('id')
-        .called(window.mixpanel.identify)
-        .args('id')
-        .called(window.mixpanel.register)
-        .args({ id: 'id' });
+        .called(window.mixpanel.identify, 'id')
+        .called(window.mixpanel.register, { id: 'id' });
     });
 
     it('should send traits', function(){
-      test(mixpanel)
+      test
         .identify(null, { trait: true })
-        .called(window.mixpanel.register)
-        .args({ trait: true });
+        .called(window.mixpanel.register, { trait: true });
     });
 
     it('should send an id and traits', function(){
-      test(mixpanel)
+      test
         .identify('id', { trait: true })
-        .called(window.mixpanel.identify)
-        .args('id')
-        .called(window.mixpanel.register)
-        .args({ trait: true, id: 'id' });
+        .called(window.mixpanel.identify, 'id')
+        .called(window.mixpanel.register, { trait: true, id: 'id' });
     });
 
     it('should use an id as a name tag', function(){
-      test(mixpanel)
+      test
         .identify('id')
-        .called(window.mixpanel.name_tag)
-        .args('id');
+        .called(window.mixpanel.name_tag, 'id');
     });
 
     it('should prefer a username as a name tag', function(){
-      test(mixpanel)
+      test
         .identify('id', { username: 'username' })
-        .called(window.mixpanel.name_tag)
-        .args('username');
+        .called(window.mixpanel.name_tag, 'username');
     });
 
     it('should prefer an email as a name tag', function(){
-      test(mixpanel).identify('id', {
-        username: 'username',
-        email: 'name@example.com'
-      });
-      assert(window.mixpanel.name_tag.calledWith('name@example.com'));
+      test
+        .identify('id', {
+          username: 'username',
+          email: 'name@example.com'
+        })
+        .called(window.mixpanel.name_tag, 'name@example.com');
     });
 
     it('should send traits to Mixpanel People', function(){
-      mixpanel.options.people = true;
-      test(mixpanel).identify(null, { trait: true });
-      assert(window.mixpanel.people.set.calledWith({ trait: true }));
+      test
+        .option('people', true)
+        .identify(null, { trait: true })
+        .called(window.mixpanel.people.set, { trait: true });
     });
 
     it('should alias traits', function(){
       var date = new Date();
-      test(mixpanel).identify(null, {
-        created: date,
-        email: 'name@example.com',
-        firstName: 'first',
-        lastName: 'last',
-        lastSeen: date,
-        name: 'name',
-        username: 'username',
-        phone: 'phone'
-      });
-      assert(window.mixpanel.register.calledWith({
-        $created: date,
-        $email: 'name@example.com',
-        $first_name: 'first',
-        $last_name: 'last',
-        $last_seen: date,
-        $name: 'name',
-        $username: 'username',
-        $phone: 'phone'
-      }));
+      test
+        .identify(null, {
+          created: date,
+          email: 'name@example.com',
+          firstName: 'first',
+          lastName: 'last',
+          lastSeen: date,
+          name: 'name',
+          username: 'username',
+          phone: 'phone'
+        })
+        .called(window.mixpanel.register, {
+          $created: date,
+          $email: 'name@example.com',
+          $first_name: 'first',
+          $last_name: 'last',
+          $last_seen: date,
+          $name: 'name',
+          $username: 'username',
+          $phone: 'phone'
+        });
     });
 
     it('should alias traits to Mixpanel People', function(){
-      mixpanel.options.people = true;
       var date = new Date();
-      test(mixpanel).identify(null, {
-        created: date,
-        email: 'name@example.com',
-        firstName: 'first',
-        lastName: 'last',
-        lastSeen: date,
-        name: 'name',
-        username: 'username',
-        phone: 'phone'
-      });
-      assert(window.mixpanel.people.set.calledWith({
-        $created: date,
-        $email: 'name@example.com',
-        $first_name: 'first',
-        $last_name: 'last',
-        $last_seen: date,
-        $name: 'name',
-        $username: 'username',
-        $phone: 'phone'
-      }));
+      test
+        .option('people', true)
+        .identify(null, {
+          created: date,
+          email: 'name@example.com',
+          firstName: 'first',
+          lastName: 'last',
+          lastSeen: date,
+          name: 'name',
+          username: 'username',
+          phone: 'phone'
+        })
+        .called(window.mixpanel.people.set, {
+          $created: date,
+          $email: 'name@example.com',
+          $first_name: 'first',
+          $last_name: 'last',
+          $last_seen: date,
+          $name: 'name',
+          $username: 'username',
+          $phone: 'phone'
+        });
     });
 
     it('should remove .created_at', function(){
-      mixpanel.options.people = true;
       var date = new Date();
-      test(mixpanel).identify(null, {
-        created_at: date,
-        email: 'name@example.com',
-        firstName: 'first',
-        lastName: 'last',
-        lastSeen: date,
-        name: 'name',
-        username: 'username',
-        phone: 'phone'
-      });
-      assert(window.mixpanel.people.set.calledWith({
-        $created: date,
-        $email: 'name@example.com',
-        $first_name: 'first',
-        $last_name: 'last',
-        $last_seen: date,
-        $name: 'name',
-        $username: 'username',
-        $phone: 'phone'
-      }));
-    })
+      test
+        .option('people', true)
+        .identify(null, {
+          created_at: date,
+          email: 'name@example.com',
+          firstName: 'first',
+          lastName: 'last',
+          lastSeen: date,
+          name: 'name',
+          username: 'username',
+          phone: 'phone'
+        })
+        .called(window.mixpanel.people.set, {
+          $created: date,
+          $email: 'name@example.com',
+          $first_name: 'first',
+          $last_name: 'last',
+          $last_seen: date,
+          $name: 'name',
+          $username: 'username',
+          $phone: 'phone'
+        });
+    });
   });
 
   describe('#track', function(){
     beforeEach(function(){
-      mixpanel.initialize();
-      window.mixpanel.track = sinon.spy();
-      window.mixpanel.people.increment = sinon.spy();
-      window.mixpanel.people.set = sinon.spy();
-      window.mixpanel.people.track_charge = sinon.spy();
+      test
+        .initialize()
+        .spy(window.mixpanel, 'track')
+        .spy(window.mixpanel, 'people.increment')
+        .spy(window.mixpanel, 'people.set')
+        .spy(window.mixpanel, 'people.track_charge');
     });
 
     it('should send an event', function(){
-      test(mixpanel).track('event');
-      assert(window.mixpanel.track.calledWith('event'));
+      test
+        .track('event')
+        .called(window.mixpanel.track, 'event');
     });
 
     it('should send an event and properties', function(){
-      test(mixpanel).track('event', { property: true });
-      assert(window.mixpanel.track.calledWith('event', { property: true }));
+      test
+        .track('event', { property: true })
+        .called(window.mixpanel.track, 'event', { property: true });
     });
 
     it('should send a revenue property to Mixpanel People', function(){
-      mixpanel.options.people = true;
-      test(mixpanel).track('event', { revenue: 9.99 });
-      assert(window.mixpanel.people.track_charge.calledWith(9.99));
+      test
+        .option('people', true)
+        .track('event', { revenue: 9.99 })
+        .called(window.mixpanel.people.track_charge, 9.99);
     });
 
     it('should convert dates to iso strings', function(){
       var date = new Date();
-      test(mixpanel).track('event', { date: date });
-      assert(window.mixpanel.track.calledWith('event', { date: iso(date) }));
+      test
+        .track('event', { date: date })
+        .called(window.mixpanel.track, 'event', { date: iso(date) });
     });
 
     it('should increment events that are in .increments option', function(){
-      mixpanel.options.increments = [0, 'my event', 1];
-      mixpanel.options.people = true;
-      test(mixpanel).track('my event');
-      assert(window.mixpanel.people.increment.calledWith('my event'));
+      test
+        .option('increments', [0, 'my event', 1])
+        .option('people', true)
+        .track('my event')
+        .called(window.mixpanel.people.increment, 'my event');
     })
 
     it('should should update people property if the event is in .increments', function(){
-      mixpanel.options.increments = ['event'];
-      mixpanel.options.people = true;
-      test(mixpanel).track('event');
-      assert(window.mixpanel.people.increment.calledWith('event'));
-      assert(window.mixpanel.people.set.calledWith('Last event', new Date));
+      test
+        .option('increments', ['event'])
+        .option('people', true)
+        .track('event')
+        .called(window.mixpanel.people.increment, 'event')
+        .called(window.mixpanel.people.set, 'Last event', new Date);
     })
 
     it('should remove mixpanel\'s reserved properties', function(){
-      test(mixpanel).track('event', {
-        distinct_id: 'string',
-        ip: 'string',
-        mp_name_tag: 'string',
-        mp_note: 'string',
-        token: 'string'
-      });
-      assert(window.mixpanel.track.calledWith('event', {}));
+      test
+        .track('event', {
+          distinct_id: 'string',
+          ip: 'string',
+          mp_name_tag: 'string',
+          mp_note: 'string',
+          token: 'string'
+        })
+        .called(window.mixpanel.track, 'event', {});
     });
   });
 
   describe('#alias', function(){
     beforeEach(function(){
-      mixpanel.initialize();
-      window.mixpanel.alias = sinon.spy();
+      test
+        .initialize()
+        .spy(window.mixpanel, 'alias');
     });
 
     it('should send a new id', function(){
-      test(mixpanel).alias('new');
-      assert(window.mixpanel.alias.calledWith('new'));
+      test
+        .alias('new')
+        .called(window.mixpanel.alias, 'new');
     });
 
     it('should send a new and old id', function(){
-      test(mixpanel).alias('new', 'old');
-      assert(window.mixpanel.alias.calledWith('new', 'old'));
+      test
+        .alias('new', 'old')
+        .called(window.mixpanel.alias, 'new', 'old');
     });
   });
-
 });


### PR DESCRIPTION
@ianstormtaylor @yields here is how the tests start to look with the new stuff. also ran into some new cases and tried some stuff. let me know what you think!

What should we do for these cases?

---

``` js
it('should call #load', function(){
  test
    .initialize()
    .called(adroll.load);
});
```

Should it be `called(adroll.load)` or `called(test.load)`, or even `called('load')`?

How about for this case, should we just leave `assert` or built it into `test`?

``` js
it('should test window.__adroll', function(){
  assert(!test.loaded());
  window.__adroll = {};
  assert(test.loaded());
});
```

---

``` js
beforeEach(function(){
  test.initialize();
  test.load.restore();
});
```

Should it be chained?

``` js
beforeEach(function(){
  test
    .initialize()
    .load.restore();
});
```

That looks weird. But it's like why not chain the first, if we would chain this?

``` js
beforeEach(function(){
  test
    .initialize()
    .spy(window.__adroll, 'record_user');
});
```

---

``` js
beforeEach(function(){
  adroll.options.events = { event: 'segment' };
});
```

Should we use `test` instead, and have the `test.options` object just set to that?

``` js
beforeEach(function(){
  test.options.events = { event: 'segment' };
});
```

Or maybe even do this, since maybe you never set the `options` directly as a developer (is it always done in the admin panel)?

``` js
beforeEach(function(){
  test.option('events', { event: 'segment' });
});
```

---

``` js
beforeEach(function(){
  test
    .spy(window.__adroll, 'record_user');
});
```

For that, should we put it on oneline or stick to the dsl?

``` js
beforeEach(function(){
  test.spy(window.__adroll, 'record_user');
});
```
