### PR TITLE
refactor tests to dsl

### DIFF
--- a/lib/quantcast/test.js
+++ b/lib/quantcast/test.js
@@ -1,13 +1,13 @@
 
+var tester = require('analytics.js-integration-tester');
+var analytics = require('analytics.js');
+var Quantcast = require('./index');
+var assert = require('assert');
+var sinon = require('sinon');
+
 describe('Quantcast', function(){
-
-  var analytics = require('analytics.js');
-  var assert = require('assert');
-  var Quantcast = require('./index')
-  var sinon = require('sinon');
-  var test = require('analytics.js-integration-tester');
-
   var quantcast;
+  var test;
   var settings = {
     pCode: 'p-ZDsjJUtp583Se'
   };
@@ -15,16 +15,16 @@ describe('Quantcast', function(){
   beforeEach(function(){
     analytics.use(Quantcast);
     quantcast = new Quantcast.Integration(settings);
-    quantcast.initialize(); // noop
+    test = tester(quantcast);
   });
 
   afterEach(function(){
-    quantcast.reset();
+    test.reset();
     analytics.user().reset();
   });
 
   it('should have the right settings', function(){
-    test(quantcast)
+    test
       .name('Quantcast')
       .assumesPageview()
       .readyOnInitialize()
@@ -35,24 +35,24 @@ describe('Quantcast', function(){
   });
 
   describe('#initialize', function(){
-    beforeEach(function(){
-      sinon.stub(quantcast, 'load');
-    });
-
     it('should push the pCode', function(){
-      quantcast.initialize();
-      assert(window._qevents[0].qacct === settings.pCode);
+      // XXX: should refactor this test too, to use `.called`
+      test
+        .initialize()
+        .equal(window._qevents[0].qacct, settings.pCode);
     });
 
     it('should push the user id', function(){
       analytics.user().identify('id');
-      quantcast.initialize();
-      assert(window._qevents[0].uid === 'id');
+      test
+        .initialize()
+        .equal(window._qevents[0].uid, 'id');
     });
 
     it('should call #load', function(){
-      quantcast.initialize();
-      assert(quantcast.load.called);
+      test
+        .initialize()
+        .called(quantcast.load);
     });
 
     it('should push "refresh" with labels when given a page', function(){
@@ -67,24 +67,23 @@ describe('Quantcast', function(){
 
   describe('#loaded', function(){
     it('should test window.__qc', function(){
-      assert(!quantcast.loaded());
+      assert(!test.loaded());
       window.__qc = {};
-      assert(quantcast.loaded());
+      assert(test.loaded());
     });
   });
 
   describe('#load', function(){
     beforeEach(function(){
-      sinon.stub(quantcast, 'load');
-      quantcast.initialize();
-      quantcast.load.restore();
+      test.initialize();
+      test.load.restore();
     });
 
-    it('should change loaded state', function (done) {
-      assert(!quantcast.loaded());
-      quantcast.load(function (err) {
+    it('should change loaded state', function(done){
+      assert(!test.loaded());
+      test.load(function(err){
         if (err) return done(err);
-        assert(quantcast.loaded());
+        assert(test.loaded());
         done();
       });
     });
@@ -92,51 +91,61 @@ describe('Quantcast', function(){
 
   describe('#page', function(){
     beforeEach(function(){
-      sinon.stub(quantcast, 'load');
-      quantcast.initialize();
+      test.spy(window._qevents, 'push');
     });
 
-    it('should push a refresh event', function(){
-      test(quantcast).page();
-      var item = window._qevents[1];
-      assert(item.event === 'refresh');
-    });
+    // XXX: all of these need to have extra props added to the `.called` args
 
-    it('should push the pCode', function(){
-      test(quantcast).page();
-      var item = window._qevents[1];
-      assert(item.qacct === settings.pCode);
+    it('should push a refresh event and pcode', function(){
+      test
+        .initialize()
+        .page()
+        .called(window._qevents.push)
+        .called(window._qevents.push, {
+          event: 'refresh',
+          qacct: settings.pCode
+        });
     });
 
     it('should push the page name as a label', function(){
-      test(quantcast).page('Page Name');
-      var item = window._qevents[1];
-      assert(item.labels === 'page.Page Name');
+      test
+        .initialize()
+        .page('Page Name')
+        .called(window._qevents.push)
+        .called(window._qevents.push, { labels: 'page.Page Name' });
     });
 
     it('should push the page name as a label without commas', function(){
-      test(quantcast).page('Page, Name');
-      var item = window._qevents[1];
-      assert(item.labels === 'page.Page; Name');
+      test
+        .initialize()
+        .page('Page, Name')
+        .called(window._qevents.push)
+        .called(window._qevents.push, { labels: 'page.Page; Name' });
     });
 
     it('should push the page category and name as labels', function(){
-      test(quantcast).page('Category', 'Page');
-      var item = window._qevents[1];
-      assert(item.labels === ('page.Category.Page'));
+      test
+        .initialize()
+        .page('Category', 'Page')
+        .called(window._qevents.push)
+        .called(window._qevents.push, { labels: 'page.Category.Page' });
     });
 
     it('should push the user id', function(){
       analytics.user().identify('id');
-      test(quantcast).page();
-      var item = window._qevents[1];
-      assert(item.uid === 'id');
+      test
+        .initialize()
+        .page()
+        .called(window._qevents.push)
+        .called(window._qevents.push, { uid: 'id' });
     });
 
     it('should call `#initialize` with `#page` once the integration is ready', function(){
       quantcast._initialized = false;
-      quantcast.initialize = sinon.spy();
-      test(quantcast).page('name');
+      test
+        .spy(quantcast, 'initialize')
+        .page('name')
+        // XXX?
       assert('page' == quantcast.initialize.args[0][0].action());
     })
 


### PR DESCRIPTION
@ianstormtaylor here is another bit of tests ported to the DSL, with a few new cases to resolve. what would you recommend? There are some inline comments with `XXX` too.

---

``` js
it('should push a refresh event', function(){
  test.page();
  var item = window._qevents[1];
  assert(item.event === 'refresh');
});
```

one option, somehow skipping the first step by only saying it was called, but not specifying the arguments, but this wouldn't technically work (something like it may tho):

``` js
beforeEach(function(){
  test.spy(window._qevents, 'push');
});

it('should push a refresh event', function(){
  test
    .page()
    .called(window._qevents.push)
    .called(window._qevents.push, { event: 'refresh' });
});
```

another option, specify the index:

``` js
it('should push a refresh event', function(){
  test
    .page()
    .called(window._qevents.push, { event: 'refresh' })
      .index(1);
});
```

or

``` js
it('should push a refresh event', function(){
  test
    .page()
    .called(1, window._qevents.push, { event: 'refresh' });
});
```

Don't like either of those b/c they're confusing?

Another option is to just test for the first item as well, which might be better (and would be helpful for future people).

``` js
it('should push a refresh event', function(){
  test
    .page()
    .called(window._qevents.push, { some: user });
    .called(window._qevents.push, { event: 'refresh' });
});
```
