### PR TITLE
google-analytics: port tests to new api

### DIFF
--- a/lib/google-analytics/index.js
+++ b/lib/google-analytics/index.js
@@ -1,31 +1,33 @@
 
-var callback = require('callback');
-var canonical = require('canonical');
-var each = require('each');
+/**
+ * Module dependencies.
+ */
+
 var integration = require('analytics.js-integration');
-var is = require('is');
-var load = require('load-script');
 var push = require('global-queue')('_gaq');
-var Track = require('facade').Track;
 var length = require('object').length;
+var canonical = require('canonical');
+var Track = require('facade').Track;
+var callback = require('callback');
+var load = require('load-script');
 var keys = require('object').keys;
 var dot = require('obj-case');
+var each = require('each');
 var type = require('type');
 var url = require('url');
+var is = require('is');
 var group;
 var user;
-
 
 /**
  * Expose plugin.
  */
 
-module.exports = exports = function (analytics) {
+module.exports = exports = function(analytics){
   analytics.addIntegration(GA);
   group = analytics.group();
   user = analytics.user();
 };
-
 
 /**
  * Expose `GA` integration.
@@ -55,13 +57,12 @@ var GA = exports.Integration = integration('Google Analytics')
   .option('metrics', {})
   .option('dimensions', {});
 
-
 /**
  * When in "classic" mode, on `construct` swap all of the method to point to
  * their classic counterparts.
  */
 
-GA.on('construct', function (integration) {
+GA.on('construct', function(integration){
   if (!integration.options.classic) return;
   integration.initialize = integration.initializeClassic;
   integration.load = integration.loadClassic;
@@ -71,19 +72,18 @@ GA.on('construct', function (integration) {
   integration.completedOrder = integration.completedOrderClassic;
 });
 
-
 /**
  * Initialize.
  *
  * https://developers.google.com/analytics/devguides/collection/analyticsjs/advanced
  */
 
-GA.prototype.initialize = function () {
+GA.prototype.initialize = function(){
   var opts = this.options;
 
   // setup the tracker globals
   window.GoogleAnalyticsObject = 'ga';
-  window.ga = window.ga || function () {
+  window.ga = window.ga || function(){
     window.ga.q = window.ga.q || [];
     window.ga.q.push(arguments);
   };
@@ -116,17 +116,15 @@ GA.prototype.initialize = function () {
   this.load();
 };
 
-
 /**
  * Loaded?
  *
  * @return {Boolean}
  */
 
-GA.prototype.loaded = function () {
+GA.prototype.loaded = function(){
   return !! window.gaplugins;
 };
-
 
 /**
  * Load the Google Analytics library.
@@ -134,10 +132,9 @@ GA.prototype.loaded = function () {
  * @param {Function} callback
  */
 
-GA.prototype.load = function (callback) {
+GA.prototype.load = function(callback){
   load('//www.google-analytics.com/analytics.js', callback);
 };
-
 
 /**
  * Page.
@@ -147,7 +144,7 @@ GA.prototype.load = function (callback) {
  * @param {Page} page
  */
 
-GA.prototype.page = function (page) {
+GA.prototype.page = function(page){
   var category = page.category();
   var props = page.properties();
   var name = page.fullName();
@@ -176,7 +173,6 @@ GA.prototype.page = function (page) {
   }
 };
 
-
 /**
  * Track.
  *
@@ -186,10 +182,9 @@ GA.prototype.page = function (page) {
  * @param {Track} event
  */
 
-GA.prototype.track = function (track, options) {
+GA.prototype.track = function(track, options){
   var opts = options || track.options(this.name);
   var props = track.properties();
-
   window.ga('send', 'event', {
     eventAction: track.event(),
     eventCategory: props.category || this._category || 'All',
@@ -255,7 +250,7 @@ GA.prototype.completedOrder = function(track){
  * https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApiBasicConfiguration
  */
 
-GA.prototype.initializeClassic = function () {
+GA.prototype.initializeClassic = function(){
   var opts = this.options;
   var anonymize = opts.anonymizeIp;
   var db = opts.doubleClick;
@@ -288,14 +283,13 @@ GA.prototype.initializeClassic = function () {
   this.load();
 };
 
-
 /**
  * Loaded? (classic)
  *
  * @return {Boolean}
  */
 
-GA.prototype.loadedClassic = function () {
+GA.prototype.loadedClassic = function(){
   return !! (window._gaq && window._gaq.push !== Array.prototype.push);
 };
 
@@ -306,7 +300,7 @@ GA.prototype.loadedClassic = function () {
  * @param {Function} callback
  */
 
-GA.prototype.loadClassic = function (callback) {
+GA.prototype.loadClassic = function(callback){
   if (this.options.doubleClick) {
     load('//stats.g.doubleclick.net/dc.js', callback);
   } else {
@@ -317,7 +311,6 @@ GA.prototype.loadClassic = function (callback) {
   }
 };
 
-
 /**
  * Page (classic).
  *
@@ -326,7 +319,7 @@ GA.prototype.loadClassic = function (callback) {
  * @param {Page} page
  */
 
-GA.prototype.pageClassic = function (page) {
+GA.prototype.pageClassic = function(page){
   var opts = page.options(this.name);
   var category = page.category();
   var props = page.properties();
@@ -348,7 +341,6 @@ GA.prototype.pageClassic = function (page) {
   }
 };
 
-
 /**
  * Track (classic).
  *
@@ -357,7 +349,7 @@ GA.prototype.pageClassic = function (page) {
  * @param {Track} track
  */
 
-GA.prototype.trackClassic = function (track, options) {
+GA.prototype.trackClassic = function(track, options){
   var opts = options || track.options(this.name);
   var props = track.properties();
   var revenue = track.revenue();
@@ -421,13 +413,12 @@ GA.prototype.completedOrderClassic = function(track){
  * @param {Object} options
  */
 
-function path (properties, options) {
+function path(properties, options) {
   if (!properties) return;
   var str = properties.path;
   if (options.includeSearch && properties.search) str += properties.search;
   return str;
 }
-
 
 /**
  * Format the value property to Google's liking.
@@ -436,7 +427,7 @@ function path (properties, options) {
  * @return {Number}
  */
 
-function formatValue (value) {
+function formatValue(value) {
   if (!value || value < 0) return 0;
   return Math.round(value);
 }

--- a/lib/google-analytics/test.js
+++ b/lib/google-analytics/test.js
@@ -1,17 +1,27 @@
 
-describe('Google Analytics', function () {
+var Analytics = require('analytics.js').constructor;
+var integration = require('analytics.js-integration');
+var tester = require('segmentio/analytics.js-integration-tester@1.3.0');
+var plugin = require('./');
 
-  var analytics = require('analytics.js');
-  var assert = require('assert');
-  var equal = require('equals');
-  var GA = require('./index')
-  var sinon = require('sinon');
-  var test = require('analytics.js-integration-tester');
+describe('Google Analytics', function(){
+  var GA = plugin.Integration;
+  var ga;
+  var analytics;
 
-  it('should have the right settings', function () {
-    var ga = new GA.Integration();
-    test(ga)
-      .name('Google Analytics')
+  beforeEach(function(){
+    analytics = new Analytics;
+    analytics.use(plugin);
+    analytics.use(tester);
+  });
+
+  afterEach(function(){
+    analytics.restore();
+    analytics.reset();
+  });
+
+  it('should have the right settings', function(){
+    analytics.validate(GA, integration('Google Analytics')
       .readyOnLoad()
       .global('ga')
       .global('_gaq')
@@ -24,12 +34,10 @@ describe('Google Analytics', function () {
       .option('ignoredReferrers', null)
       .option('siteSpeedSampleRate', 1)
       .option('trackingId', '')
-      .option('trackNamedPages', true);
+      .option('trackNamedPages', true));
   });
 
-  describe('Universal', function () {
-
-    var ga;
+  describe('Universal', function(){
     var settings = {
       anonymizeIp: true,
       domain: 'none',
@@ -37,410 +45,411 @@ describe('Google Analytics', function () {
       trackingId: 'UA-27033709-12'
     };
 
-    beforeEach(function () {
-      analytics.use(GA);
-      ga = new GA.Integration(settings);
-      analytics.user().reset();
-      analytics.group().reset();
+    beforeEach(function(){
+      ga = new GA(settings);
+      analytics.add(ga);
     });
 
-    afterEach(function () {
+    after(function(){
       ga.reset();
     });
 
-    describe('#initialize', function () {
-      beforeEach(function () {
-        ga.load = sinon.spy();
-      });
-
-      it('should require "displayfeatures" if .doubleClick option is `true`', function(){
-        ga.options.doubleClick = true;
-        ga.initialize();
-        assert(equal(window.ga.q[1], ['require', 'displayfeatures']));
-      })
-
-      it('should create window.GoogleAnalyticsObject', function () {
-        assert(!window.GoogleAnalyticsObject);
-        ga.initialize();
-        assert('ga' === window.GoogleAnalyticsObject);
-      });
-
-      it('should create window.ga', function () {
-        assert(!window.ga);
-        ga.initialize();
-        assert('function' === typeof window.ga);
-      });
-
-      it('should create window.ga.l', function () {
-        assert(!window.ga);
-        ga.initialize();
-        assert('number' === typeof window.ga.l);
-      });
-
-      it('should call window.ga.create with options', function () {
-        ga.initialize();
-        assert(equal(window.ga.q[0], ['create', settings.trackingId, {
-          cookieDomain: settings.domain,
-          siteSpeedSampleRate: settings.siteSpeedSampleRate,
-          allowLinker: true
-        }]));
-      });
-
-      it('should anonymize the ip', function () {
-        ga.initialize();
-        assert(equal(window.ga.q[1], ['set', 'anonymizeIp', true]));
-      });
-
-      it('should call #load', function () {
-        ga.initialize();
-        assert(ga.load.called);
-      });
-
-      it('should not send universal user id by default', function(){
-        analytics.user().id('baz');
-        ga.initialize();
-        assert(!equal(window.ga.q[1], ['set', '&uid', 'baz']));
-      })
-
-      it('should send universal user id if sendUserId option is true and user.id() is truthy', function(){
-        analytics.user().id('baz');
-        ga.options.sendUserId = true;
-        ga.initialize();
-        assert(equal(window.ga.q[1], ['set', '&uid', 'baz']));
-      })
-
-      it('should map custom dimensions & metrics using user.traits()', function(){
-        ga.options.metrics = { firstName: 'metric1', last_name: 'metric2' };
-        ga.options.dimensions = { Age: 'dimension2' };
-        analytics.user().traits({ firstName: 'John', lastName: 'Doe', age: 20 });
-        ga.initialize();
-
-        assert(equal(window.ga.q[2], ['set', {
-          metric1: 'John',
-          metric2: 'Doe',
-          dimension2: 20
-        }]));
-      })
-
-      it('should not set metrics and dimensions if there are no traits', function(){
-        ga.options.metrics = { metric1: 'something' };
-        ga.options.dimensions = { dimension3: 'industry' };
-        ga.initialize();
-
-        assert(equal(window.ga.q[2], undefined));
-      })
-    });
-
-    describe('#loaded', function () {
-      it('should test window.gaplugins', function () {
-        assert(!ga.loaded());
-        window.gaplugins = {};
-        assert(ga.loaded());
-      });
-    });
-
-    describe('#load', function () {
-      beforeEach(function () {
-        sinon.stub(ga, 'load');
-        ga.initialize();
-        ga.load.restore();
-      });
-
-      it('should change loaded state', function (done) {
-        assert(!ga.loaded());
-        ga.load(function (err) {
-          if (err) return done(err);
-          assert(ga.loaded());
-          done();
-        });
-      });
-
-      it('should call ready on load', function (done) {
-        ga.on('ready', done);
-        ga.load();
-      });
-    });
-
-    describe('#page', function () {
-      beforeEach(function () {
-        ga.initialize();
-        window.ga = sinon.spy();
-      });
-
-      it('should send a page view', function () {
-        test(ga).page();
-        assert(window.ga.calledWith('send', 'pageview', {
-          page: undefined,
-          title: undefined,
-          location: undefined
-        }));
-      });
-
-      it('should send a page view with properties', function () {
-        test(ga).page('category', 'name', { url: 'url', path: '/path' });
-        assert(window.ga.calledWith('send', 'pageview', {
-          page: '/path',
-          title: 'category name',
-          location: 'url'
-        }));
-      });
-
-      it('should send the query if its included', function () {
-        ga.options.includeSearch = true;
-        test(ga).page('category', 'name', { url: 'url', path: '/path', search: '?q=1' });
-        assert(window.ga.calledWith('send', 'pageview', {
-          page: '/path?q=1',
-          title: 'category name',
-          location: 'url'
-        }));
-      });
-
-      it('should track a named page', function () {
-        test(ga).page(null, 'Name');
-        assert(window.ga.calledWith('send', 'event', {
-          eventCategory: 'All',
-          eventAction: 'Viewed Name Page',
-          eventLabel: undefined,
-          eventValue: 0,
-          nonInteraction: true
-        }));
-      });
-
-      it('should track a name + category page', function () {
-        test(ga).page('Category', 'Name');
-        assert(window.ga.calledWith('send', 'event', {
-          eventCategory: 'Category',
-          eventAction: 'Viewed Category Name Page',
-          eventLabel: undefined,
-          eventValue: 0,
-          nonInteraction: true
-        }));
-      });
-
-      it('should track a categorized page', function () {
-        test(ga).page('Category', 'Name');
-        assert(window.ga.calledWith('send', 'event', {
-          eventCategory: 'Category',
-          eventAction: 'Viewed Category Page',
-          eventLabel: undefined,
-          eventValue: 0,
-          nonInteraction: true
-        }));
-      });
-
-      it('should not track a named or categorized page when the option is off', function () {
-        ga.options.trackNamedPages = false;
-        ga.options.trackCategorizedPages = false;
-        test(ga).page(null, 'Name');
-        test(ga).page('Category', 'Name');
-        assert(window.ga.calledTwice);
-      });
-    });
-
-    describe('#track', function () {
-      beforeEach(function () {
-        ga.initialize();
-        window.ga = sinon.spy();
-      });
-
-      it('should send an event', function () {
-        test(ga).track('event');
-        assert(window.ga.calledWith('send', 'event', {
-          eventCategory: 'All',
-          eventAction: 'event',
-          eventLabel: undefined,
-          eventValue: 0,
-          nonInteraction: undefined
-        }));
-      });
-
-      it('should send a category property', function () {
-        test(ga).track('event', { category: 'category' });
-        assert(window.ga.calledWith('send', 'event', {
-          eventCategory: 'category',
-          eventAction: 'event',
-          eventLabel: undefined,
-          eventValue: 0,
-          nonInteraction: undefined
-        }));
-      });
-
-      it('should send a stored category', function () {
-        test(ga).page('category');
-        test(ga).track('event', {});
-        assert(window.ga.calledWith('send', 'event', {
-          eventCategory: 'category',
-          eventAction: 'event',
-          eventLabel: undefined,
-          eventValue: 0,
-          nonInteraction: undefined
-        }));
-      });
-
-      it('should send a category property even if there is a stored category', function () {
-        test(ga).page('category(page)');
-        test(ga).track('event', { category: 'category(track)' });
-        assert(window.ga.calledWith('send', 'event', {
-          eventCategory: 'category(track)',
-          eventAction: 'event',
-          eventLabel: undefined,
-          eventValue: 0,
-          nonInteraction: undefined
-        }));
-      });
-
-      it('should send a label property', function () {
-        test(ga).track('event', { label: 'label' });
-        assert(window.ga.calledWith('send', 'event', {
-          eventCategory: 'All',
-          eventAction: 'event',
-          eventLabel: 'label',
-          eventValue: 0,
-          nonInteraction: undefined
-        }));
-      });
-
-      it('should send a rounded value property', function () {
-        test(ga).track('event', { value: 1.1 });
-        assert(window.ga.calledWith('send', 'event', {
-          eventCategory: 'All',
-          eventAction: 'event',
-          eventLabel: undefined,
-          eventValue: 1,
-          nonInteraction: undefined
-        }));
-      });
-
-      it('should prefer a rounded revenue property', function () {
-        test(ga).track('event', { revenue: 9.99 });
-        assert(window.ga.calledWith('send', 'event', {
-          eventCategory: 'All',
-          eventAction: 'event',
-          eventLabel: undefined,
-          eventValue: 10,
-          nonInteraction: undefined
-        }));
-      });
-
-      it('should send a non-interaction property', function () {
-        test(ga).track('event', { noninteraction: true });
-        assert(window.ga.calledWith('send', 'event', {
-          eventCategory: 'All',
-          eventAction: 'event',
-          eventLabel: undefined,
-          eventValue: 0,
-          nonInteraction: true
-        }));
-      });
-
-      it('should send a non-interaction option', function () {
-        test(ga).track('event', {}, { 'Google Analytics': { noninteraction: true } });
-        assert(window.ga.calledWith('send', 'event', {
-          eventCategory: 'All',
-          eventAction: 'event',
-          eventLabel: undefined,
-          eventValue: 0,
-          nonInteraction: true
-        }));
-      });
-    });
-
-    describe('ecommerce', function(){
+    describe('before loading', function(){
       beforeEach(function(){
-        ga.initialize();
-        window.ga = sinon.spy();
-      })
+        analytics.stub(ga, 'load');
+      });
 
-      it('should require ecommerce.js', function(){
-        test(ga).track('completed order', { orderId: 'ee099bf7' });
-        assert(window.ga.calledWith('require', 'ecommerce', 'ecommerce.js'));
-        assert(ga.ecommerce);
-      })
+      afterEach(function(){
+        ga.reset();
+      });
 
-      it('should not require ecommerce if .ecommerce is true', function(){
-        ga.ecommerce = true;
-        test(ga).track('completed order', { orderId: 'e213e4da' });
-        assert(!window.ga.calledWith('require', 'ecommerce', 'ecommerce.js'));
-      })
+      describe('#initialize', function(){
+        it('should require "displayfeatures" if .doubleClick option is `true`', function(){
+          ga.options.doubleClick = true;
+          analytics.initialize();
+          analytics.page();
+          analytics.deepEqual(window.ga.q[1], ['require', 'displayfeatures']);
+        });
 
-      it('should send simple ecommerce data', function(){
-        test(ga).track('completed order', { orderId: '7306cc06' });
-        assert(3 == window.ga.args.length);
-        assert('ecommerce:addTransaction' == window.ga.args[1][0]);
-        assert('ecommerce:send' == window.ga.args[2][0]);
-      })
+        it('should create window.GoogleAnalyticsObject', function(){
+          analytics.assert(!window.GoogleAnalyticsObject);
+          analytics.initialize();
+          analytics.page();
+          analytics.assert('ga' === window.GoogleAnalyticsObject);
+        });
 
-      it('should send ecommerce data', function(){
-        test(ga).track('completed order', {
-          orderId: '780bc55',
-          total: 99.99,
-          shipping: 13.99,
-          tax: 20.99,
-          products: [{
-            quantity: 1,
-            price: 24.75,
+        it('should create window.ga', function(){
+          analytics.assert(!window.ga);
+          analytics.initialize();
+          analytics.page();
+          analytics.assert('function' === typeof window.ga);
+        });
+
+        it('should create window.ga.l', function(){
+          analytics.assert(!window.ga);
+          analytics.initialize();
+          analytics.page();
+          analytics.assert('number' === typeof window.ga.l);
+        });
+
+        it('should call window.ga.create with options', function(){
+          analytics.initialize();
+          analytics.page();
+          analytics.deepEqual(window.ga.q[0], ['create', settings.trackingId, {
+            cookieDomain: settings.domain,
+            siteSpeedSampleRate: settings.siteSpeedSampleRate,
+            allowLinker: true
+          }]);
+        });
+
+        it('should anonymize the ip', function(){
+          analytics.initialize();
+          analytics.page();
+          analytics.deepEqual(window.ga.q[1], ['set', 'anonymizeIp', true]);
+        });
+
+        it('should call #load', function(){
+          analytics.initialize();
+          analytics.page();
+          analytics.called(ga.load);
+        });
+
+        it('should not send universal user id by default', function(){
+          analytics.user().id('baz');
+          analytics.initialize();
+          analytics.page();
+          analytics.notDeepEqual(window.ga.q[1], ['set', '&uid', 'baz']);
+        });
+
+        it('should send universal user id if sendUserId option is true and user.id() is truthy', function(){
+          analytics.user().id('baz');
+          ga.options.sendUserId = true;
+          analytics.initialize();
+          analytics.page();
+          analytics.deepEqual(window.ga.q[1], ['set', '&uid', 'baz']);
+        });
+
+        it('should map custom dimensions & metrics using user.traits()', function(){
+          ga.options.metrics = { firstName: 'metric1', last_name: 'metric2' };
+          ga.options.dimensions = { Age: 'dimension2' };
+          analytics.user().traits({ firstName: 'John', lastName: 'Doe', age: 20 });
+          analytics.initialize();
+          analytics.page();
+
+          analytics.deepEqual(window.ga.q[2], ['set', {
+            metric1: 'John',
+            metric2: 'Doe',
+            dimension2: 20
+          }]);
+        });
+
+        it('should not set metrics and dimensions if there are no traits', function(){
+          ga.options.metrics = { metric1: 'something' };
+          ga.options.dimensions = { dimension3: 'industry' };
+          analytics.initialize();
+          analytics.page();
+          analytics.deepEqual(window.ga.q[2], undefined);
+        });
+      });
+
+      describe('#loaded', function(){
+        it('should test window.gaplugins', function(){
+          analytics.assert(!ga.loaded());
+          window.gaplugins = {};
+          analytics.assert(ga.loaded());
+        });
+      });
+    });
+
+    describe('loading', function(){
+      it('should load', function(done){
+        analytics.load(ga, done);
+      });
+    });
+
+    describe('after loading', function(){
+      beforeEach(function(done){
+        analytics.once('ready', done);
+        analytics.initialize();
+        analytics.page();
+      });
+
+      describe('#page', function(){
+        beforeEach(function(){
+          analytics.stub(window, 'ga');
+        });
+
+        it('should send a page view', function(){
+          analytics.page();
+          analytics.called(window.ga, 'send', 'pageview', {
+            page: window.location.pathname,
+            title: document.title,
+            location: window.location.href
+          });
+        });
+
+        it('should send a page view with properties', function(){
+          analytics.page('category', 'name', { url: 'url', path: '/path' });
+          analytics.called(window.ga, 'send', 'pageview', {
+            page: '/path',
+            title: 'category name',
+            location: 'url'
+          });
+        });
+
+        it('should send the query if its included', function(){
+          ga.options.includeSearch = true;
+          analytics.page('category', 'name', { url: 'url', path: '/path', search: '?q=1' });
+          analytics.called(window.ga, 'send', 'pageview', {
+            page: '/path?q=1',
+            title: 'category name',
+            location: 'url'
+          });
+        });
+
+        it('should track a named page', function(){
+          analytics.page(null, 'Name');
+          analytics.called(window.ga, 'send', 'event', {
+            eventCategory: 'All',
+            eventAction: 'Viewed Name Page',
+            eventLabel: undefined,
+            eventValue: 0,
+            nonInteraction: true
+          });
+        });
+
+        it('should track a name + category page', function(){
+          analytics.page('Category', 'Name');
+          analytics.called(window.ga, 'send', 'event', {
+            eventCategory: 'Category',
+            eventAction: 'Viewed Category Name Page',
+            eventLabel: undefined,
+            eventValue: 0,
+            nonInteraction: true
+          });
+        });
+
+        it('should track a categorized page', function(){
+          analytics.page('Category', 'Name');
+          analytics.called(window.ga, 'send', 'event', {
+            eventCategory: 'Category',
+            eventAction: 'Viewed Category Page',
+            eventLabel: undefined,
+            eventValue: 0,
+            nonInteraction: true
+          });
+        });
+
+        it('should not track a named or categorized page when the option is off', function(){
+          ga.options.trackNamedPages = false;
+          ga.options.trackCategorizedPages = false;
+          analytics.page(null, 'Name');
+          analytics.page('Category', 'Name');
+          analytics.calledTwice(window.ga);
+        });
+      });
+
+      describe('#track', function(){
+        beforeEach(function(){
+          analytics.stub(window, 'ga');
+        });
+
+        it('should send an event', function(){
+          analytics.track('event');
+          analytics.called(window.ga, 'send', 'event', {
+            eventCategory: 'All',
+            eventAction: 'event',
+            eventLabel: undefined,
+            eventValue: 0,
+            nonInteraction: undefined
+          });
+        });
+
+        it('should send a category property', function(){
+          analytics.track('event', { category: 'category' });
+          analytics.called(window.ga, 'send', 'event', {
+            eventCategory: 'category',
+            eventAction: 'event',
+            eventLabel: undefined,
+            eventValue: 0,
+            nonInteraction: undefined
+          });
+        });
+
+        it('should send a stored category', function(){
+          analytics.page('category', 'name');
+          analytics.track('event', {});
+          analytics.called(window.ga, 'send', 'event', {
+            eventCategory: 'category',
+            eventAction: 'event',
+            eventLabel: undefined,
+            eventValue: 0,
+            nonInteraction: undefined
+          });
+        });
+
+        it('should send a category property even if there is a stored category', function(){
+          analytics.page('category(page)');
+          analytics.track('event', { category: 'category(track)' });
+          analytics.called(window.ga, 'send', 'event', {
+            eventCategory: 'category(track)',
+            eventAction: 'event',
+            eventLabel: undefined,
+            eventValue: 0,
+            nonInteraction: undefined
+          });
+        });
+
+        it('should send a label property', function(){
+          analytics.track('event', { label: 'label' });
+          analytics.called(window.ga, 'send', 'event', {
+            eventCategory: 'All',
+            eventAction: 'event',
+            eventLabel: 'label',
+            eventValue: 0,
+            nonInteraction: undefined
+          });
+        });
+
+        it('should send a rounded value property', function(){
+          analytics.track('event', { value: 1.1 });
+          analytics.called(window.ga, 'send', 'event', {
+            eventCategory: 'All',
+            eventAction: 'event',
+            eventLabel: undefined,
+            eventValue: 1,
+            nonInteraction: undefined
+          });
+        });
+
+        it('should prefer a rounded revenue property', function(){
+          analytics.track('event', { revenue: 9.99 });
+          analytics.called(window.ga, 'send', 'event', {
+            eventCategory: 'All',
+            eventAction: 'event',
+            eventLabel: undefined,
+            eventValue: 10,
+            nonInteraction: undefined
+          });
+        });
+
+        it('should send a non-interaction property', function(){
+          analytics.track('event', { noninteraction: true });
+          analytics.called(window.ga, 'send', 'event', {
+            eventCategory: 'All',
+            eventAction: 'event',
+            eventLabel: undefined,
+            eventValue: 0,
+            nonInteraction: true
+          });
+        });
+
+        it('should send a non-interaction option', function(){
+          analytics.track('event', {}, { 'Google Analytics': { noninteraction: true } });
+          analytics.called(window.ga, 'send', 'event', {
+            eventCategory: 'All',
+            eventAction: 'event',
+            eventLabel: undefined,
+            eventValue: 0,
+            nonInteraction: true
+          });
+        });
+      });
+
+      describe('ecommerce', function(){
+        beforeEach(function(){
+          analytics.stub(window, 'ga');
+        });
+
+        it('should require ecommerce.js', function(){
+          analytics.track('completed order', { orderId: 'ee099bf7' });
+          analytics.called(window.ga, 'require', 'ecommerce', 'ecommerce.js');
+          analytics.assert(ga.ecommerce);
+        });
+
+        it('should not require ecommerce if .ecommerce is true', function(){
+          ga.ecommerce = true;
+          analytics.track('completed order', { orderId: 'e213e4da' });
+          analytics.didNotCall(window.ga, 'require', 'ecommerce', 'ecommerce.js');
+        });
+
+        it('should send simple ecommerce data', function(){
+          analytics.track('completed order', { orderId: '7306cc06' });
+          analytics.assert(3 == window.ga.args.length);
+          analytics.assert('ecommerce:addTransaction' == window.ga.args[1][0]);
+          analytics.assert('ecommerce:send' == window.ga.args[2][0]);
+        });
+
+        it('should send ecommerce data', function(){
+          analytics.track('completed order', {
+            orderId: '780bc55',
+            total: 99.99,
+            shipping: 13.99,
+            tax: 20.99,
+            products: [{
+              quantity: 1,
+              price: 24.75,
+              name: 'my product',
+              sku: 'p-298'
+            }, {
+              quantity: 3,
+              price: 24.75,
+              name: 'other product',
+              sku: 'p-299'
+            }]
+          });
+
+          analytics.deepEqual(window.ga.args[1], ['ecommerce:addTransaction', {
+            id: '780bc55',
+            revenue: 99.99,
+            shipping: 13.99,
+            affiliation: undefined,
+            tax: 20.99
+          }]);
+
+          analytics.deepEqual(window.ga.args[2], ['ecommerce:addItem', {
+            id: '780bc55',
+            category: undefined,
             name: 'my product',
-            sku: 'p-298'
-          }, {
-            quantity: 3,
             price: 24.75,
+            quantity: 1,
+            sku: 'p-298'
+          }]);
+
+          analytics.deepEqual(window.ga.args[3], ['ecommerce:addItem', {
+            id: '780bc55',
+            category: undefined,
             name: 'other product',
-            sku: 'p-299'
-          }]
+            price: 24.75,
+            sku: 'p-299',
+            quantity: 3
+          }]);
+
+          analytics.deepEqual(window.ga.args[4], ['ecommerce:send']);
         });
 
-        assert(equal(window.ga.args[1], ['ecommerce:addTransaction', {
-          id: '780bc55',
-          revenue: 99.99,
-          shipping: 13.99,
-          affiliation: undefined,
-          tax: 20.99
-        }]));
+        it('should fallback to revenue', function(){
+          analytics.track('completed order', {
+            orderId: '5d4c7cb5',
+            revenue: 99.9,
+            shipping: 13.99,
+            tax: 20.99,
+            products: []
+          });
 
-        assert(equal(window.ga.args[2], ['ecommerce:addItem', {
-          id: '780bc55',
-          category: undefined,
-          name: 'my product',
-          price: 24.75,
-          quantity: 1,
-          sku: 'p-298'
-        }]));
-
-        assert(equal(window.ga.args[3], ['ecommerce:addItem', {
-          id: '780bc55',
-          category: undefined,
-          name: 'other product',
-          price: 24.75,
-          sku: 'p-299',
-          quantity: 3
-        }]));
-
-        assert(equal(window.ga.args[4], ['ecommerce:send']));
-      })
-
-      it('should fallback to revenue', function(){
-        test(ga).track('completed order', {
-          orderId: '5d4c7cb5',
-          revenue: 99.9,
-          shipping: 13.99,
-          tax: 20.99,
-          products: []
+          analytics.deepEqual(window.ga.args[1], ['ecommerce:addTransaction', {
+            id: '5d4c7cb5',
+            revenue: 99.9,
+            shipping: 13.99,
+            affiliation: undefined,
+            tax: 20.99
+          }]);
         });
-
-        assert(equal(window.ga.args[1], ['ecommerce:addTransaction', {
-          id: '5d4c7cb5',
-          revenue: 99.9,
-          shipping: 13.99,
-          affiliation: undefined,
-          tax: 20.99
-        }]));
-      })
-    })
+      });
+    });
   });
 
-  describe('Classic', function () {
-
-    var ga;
+  describe('Classic', function(){
     var settings = {
       anonymizeIp: true,
       classic: true,
@@ -450,282 +459,285 @@ describe('Google Analytics', function () {
       siteSpeedSampleRate: 42,
       trackingId: 'UA-27033709-5'
     };
-
-    beforeEach(function () {
-      analytics.use(GA);
-      ga = new GA.Integration(settings);
+    
+    beforeEach(function(){
+      ga = new GA(settings);
+      analytics.add(ga);
     });
 
-    afterEach(function () {
+    after(function(){
       ga.reset();
     });
 
-    describe('#initialize', function () {
-      beforeEach(function () {
-        ga.load = sinon.spy();
-      });
-
-      it('should create window._gaq', function () {
-        assert(!window._gaq);
-        ga.initialize();
-        assert(window._gaq instanceof Array);
-      });
-
-      it('should push the tracking id', function () {
-        ga.initialize();
-        assert(equal(window._gaq[0], ['_setAccount', settings.trackingId]));
-      });
-
-      it('should set allow linker', function () {
-        ga.initialize();
-        assert(equal(window._gaq[1], ['_setAllowLinker', true]));
-      });
-
-      it('should set anonymize ip', function () {
-        ga.initialize();
-        assert(equal(window._gaq[2], ['_gat._anonymizeIp']));
-      });
-
-      it('should set domain name', function () {
-        ga.initialize();
-        assert(equal(window._gaq[3], ['_setDomainName', settings.domain]));
-      });
-
-      it('should set site speed sample rate', function () {
-        ga.initialize();
-        assert(equal(window._gaq[4], ['_setSiteSpeedSampleRate', settings.siteSpeedSampleRate]));
-      });
-
-      it('should set enhanced link attribution', function () {
-        ga.initialize();
-        assert(equal(window._gaq[5], ['_require', 'inpage_linkid', 'http://www.google-analytics.com/plugins/ga/inpage_linkid.js']));
-      });
-
-      it('should set ignored referrers', function () {
-        ga.initialize();
-        assert(equal(window._gaq[6], ['_addIgnoredRef', settings.ignoredReferrers[0]]));
-        assert(equal(window._gaq[7], ['_addIgnoredRef', settings.ignoredReferrers[1]]));
-      });
-
-      it('should call #load', function () {
-        ga.loadClassic = sinon.spy();
-        ga.initialize();
-        assert(ga.load.called);
-      });
-    });
-
-    describe('#loaded', function () {
-      it('should test window._gaq.push', function () {
-        window._gaq = [];
-        assert(!ga.loaded());
-        window._gaq.push = function(){};
-        assert(ga.loaded());
-      });
-    });
-
-    describe('#load', function () {
-      beforeEach(function () {
-        sinon.stub(ga, 'load');
-        ga.initialize();
-        ga.load.restore();
-      });
-
-      it('should change loaded state', function (done) {
-        assert(!ga.loaded());
-        ga.load(function (err) {
-          if (err) return done(err);
-          assert(ga.loaded());
-          done();
-        });
-      });
-
-      it('should call ready on load', function (done) {
-        ga.on('ready', done);
-        ga.load();
-      });
-    });
-
-    describe('#page', function () {
-      beforeEach(function () {
-        ga.initialize();
-        window._gaq.push = sinon.spy();
-      });
-
-      it('should send a page view', function () {
-        test(ga).page();
-        assert(window._gaq.push.calledWith(['_trackPageview', undefined]));
-      });
-
-      it('should send a path', function () {
-        test(ga).page(null, null, { path: '/path' });
-        assert(window._gaq.push.calledWith(['_trackPageview', '/path']));
-      });
-
-      it('should send the query if its included', function () {
-        ga.options.includeSearch = true;
-        test(ga).page(null, null, { path: '/path', search: '?q=1' });
-        assert(window._gaq.push.calledWith(['_trackPageview', '/path?q=1']));
-      });
-
-      it('should track a named page', function () {
-        test(ga).page(null, 'Name');
-        assert(window._gaq.push.calledWith(['_trackEvent', 'All', 'Viewed Name Page', undefined, 0, true]));
-      });
-
-      it('should track a named page with a category', function () {
-        test(ga).page('Category', 'Name');
-        assert(window._gaq.push.calledWith(['_trackEvent', 'Category', 'Viewed Category Name Page', undefined, 0, true]));
-      });
-
-      it('should track a categorized page', function () {
-        test(ga).page('Category', 'Name');
-        assert(window._gaq.push.calledWith(['_trackEvent', 'Category', 'Viewed Category Page', undefined, 0, true]));
-      });
-
-      it('should not track a named or categorized page when the option is off', function () {
-        ga.options.trackNamedPages = false;
-        ga.options.trackCategorizedPages = false;
-        test(ga).page(null, 'Name');
-        test(ga).page('Category', 'Name');
-        assert(window._gaq.push.calledTwice);
-      });
-    });
-
-    describe('#track', function () {
-      beforeEach(function () {
-        ga.initialize();
-        window._gaq.push = sinon.spy();
-      });
-
-      it('should send an event', function () {
-        test(ga).track('event');
-        assert(window._gaq.push.calledWith(['_trackEvent', 'All', 'event', undefined, 0, undefined]));
-      });
-
-      it('should send a category property', function () {
-        test(ga).track('event', { category: 'category' });
-        assert(window._gaq.push.calledWith(['_trackEvent', 'category', 'event', undefined, 0, undefined]));
-      });
-
-      it('should send a stored category', function () {
-        test(ga).page('category');
-        test(ga).track('event', { category: 'category' });
-        assert(window._gaq.push.calledWith(['_trackEvent', 'category', 'event', undefined, 0, undefined]));
-      });
-
-      it('should send a label property', function () {
-        test(ga).track('event', { label: 'label' });
-        assert(window._gaq.push.calledWith(['_trackEvent', 'All', 'event', 'label', 0, undefined]));
-      });
-
-      it('should send a rounded value property', function () {
-        test(ga).track('event', { value: 1.1 });
-        assert(window._gaq.push.calledWith(['_trackEvent', 'All', 'event', undefined, 1, undefined]));
-      });
-
-      it('should prefer a rounded revenue property', function () {
-        test(ga).track('event', { revenue: 9.99 });
-        assert(window._gaq.push.calledWith(['_trackEvent', 'All', 'event', undefined, 10, undefined]));
-      });
-
-      it('should send a non-interaction property', function () {
-        test(ga).track('event', { noninteraction: true });
-        assert(window._gaq.push.calledWith(['_trackEvent', 'All', 'event', undefined, 0, true]));
-      });
-
-      it('should send a non-interaction option', function () {
-        test(ga).track('event', {}, { 'Google Analytics': { noninteraction: true } });
-        assert(window._gaq.push.calledWith(['_trackEvent', 'All', 'event', undefined, 0, true]));
-      });
-    });
-
-    describe('ecommerce', function(){
+    describe('before loading', function(){
       beforeEach(function(){
-        ga.initialize();
-        window._gaq.push = sinon.spy();
-      })
+        analytics.stub(ga, 'load');
+      });
 
-      it('should send simple ecommerce data', function(){
-        test(ga).track('completed order', { orderId: '078781c7' });
-        assert(2 == window._gaq.push.args.length);
-        assert('_addTrans' == window._gaq.push.args[0][0][0]);
-        assert('_trackTrans' == window._gaq.push.args[1][0][0]);
-      })
+      afterEach(function(){
+        ga.reset();
+      });
 
-      it('should send ecommerce data', function(){
-        test(ga).track('completed order', {
-          orderId: 'af5ccd73',
-          total: 99.99,
-          shipping: 13.99,
-          tax: 20.99,
-          products: [{
-            quantity: 1,
-            price: 24.75,
-            name: 'my product',
-            sku: 'p-298'
-          }, {
-            quantity: 3,
-            price: 24.75,
-            name: 'other product',
-            sku: 'p-299'
-          }]
+      describe('#initialize', function(){
+        it('should create window._gaq', function(){
+          analytics.assert(!window._gaq);
+          analytics.initialize();
+          analytics.page();
+          analytics.assert(window._gaq instanceof Array);
         });
 
-        assert(equal(window._gaq.push.args[0], [[
-          '_addTrans',
-          'af5ccd73',
-          undefined,
-          99.99,
-          20.99,
-          13.99,
-          undefined,
-          undefined,
-          undefined
-        ]]));
-
-        assert(equal(window._gaq.push.args[1], [[
-          '_addItem',
-          'af5ccd73',
-          'p-298',
-          'my product',
-          undefined,
-          24.75,
-          1,
-        ]]));
-
-        assert(equal(window._gaq.push.args[2], [[
-          '_addItem',
-          'af5ccd73',
-          'p-299',
-          'other product',
-          undefined,
-          24.75,
-          3
-        ]]));
-      })
-
-      it('should fallback to revenue', function(){
-        test(ga).track('completed order', {
-          orderId: 'f2ffee5c',
-          revenue: 9,
-          shipping: 3,
-          tax: 2,
-          products: []
+        it('should push the tracking id', function(){
+          analytics.initialize();
+          analytics.page();
+          analytics.deepEqual(window._gaq[0], ['_setAccount', settings.trackingId]);
         });
 
-        assert(equal(window._gaq.push.args[0], [[
-          '_addTrans',
-          'f2ffee5c',
-          undefined,
-          9,
-          2,
-          3,
-          undefined,
-          undefined,
-          undefined
-        ]]));
-      })
-    })
+        it('should set allow linker', function(){
+          analytics.initialize();
+          analytics.page();
+          analytics.deepEqual(window._gaq[1], ['_setAllowLinker', true]);
+        });
+
+        it('should set anonymize ip', function(){
+          analytics.initialize();
+          analytics.page();
+          analytics.deepEqual(window._gaq[2], ['_gat._anonymizeIp']);
+        });
+
+        it('should set domain name', function(){
+          analytics.initialize();
+          analytics.page();
+          analytics.deepEqual(window._gaq[3], ['_setDomainName', settings.domain]);
+        });
+
+        it('should set site speed sample rate', function(){
+          analytics.initialize();
+          analytics.page();
+          analytics.deepEqual(window._gaq[4], ['_setSiteSpeedSampleRate', settings.siteSpeedSampleRate]);
+        });
+
+        it('should set enhanced link attribution', function(){
+          analytics.initialize();
+          analytics.page();
+          analytics.deepEqual(window._gaq[5], ['_require', 'inpage_linkid', 'http://www.google-analytics.com/plugins/ga/inpage_linkid.js']);
+        });
+
+        it('should set ignored referrers', function(){
+          analytics.initialize();
+          analytics.page();
+          analytics.deepEqual(window._gaq[6], ['_addIgnoredRef', settings.ignoredReferrers[0]]);
+          analytics.deepEqual(window._gaq[7], ['_addIgnoredRef', settings.ignoredReferrers[1]]);
+        });
+
+        it('should call #load', function(){
+          analytics.stub(ga, 'loadClassic');
+          analytics.initialize();
+          analytics.page();
+          analytics.called(ga.load);
+        });
+      });
+
+      describe('#loaded', function(){
+        it('should test window._gaq.push', function(){
+          window._gaq = [];
+          analytics.assert(!ga.loaded());
+          window._gaq.push = function(){};
+          analytics.assert(ga.loaded());
+        });
+      });
+    });
+
+    describe('loading', function(){
+      it('should load', function(done){
+        analytics.load(ga, done);
+      });
+    });
+
+    describe('after loading', function(){
+      beforeEach(function(done){
+        analytics.once('ready', done);
+        analytics.initialize();
+        analytics.page();
+      });
+
+      describe('#page', function(){
+        beforeEach(function(){
+          analytics.stub(window._gaq, 'push');
+        });
+
+        it('should send a page view', function(){
+          analytics.page();
+          analytics.called(window._gaq.push, ['_trackPageview', window.location.pathname]);
+        });
+
+        it('should send a path', function(){
+          analytics.page(null, null, { path: '/path' });
+          analytics.called(window._gaq.push, ['_trackPageview', '/path']);
+        });
+
+        it('should send the query if its included', function(){
+          ga.options.includeSearch = true;
+          analytics.page(null, null, { path: '/path', search: '?q=1' });
+          analytics.called(window._gaq.push, ['_trackPageview', '/path?q=1']);
+        });
+
+        it('should track a named page', function(){
+          analytics.page(null, 'Name');
+          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'Viewed Name Page', undefined, 0, true]);
+        });
+
+        it('should track a named page with a category', function(){
+          analytics.page('Category', 'Name');
+          analytics.called(window._gaq.push, ['_trackEvent', 'Category', 'Viewed Category Name Page', undefined, 0, true]);
+        });
+
+        it('should track a categorized page', function(){
+          analytics.page('Category', 'Name');
+          analytics.called(window._gaq.push, ['_trackEvent', 'Category', 'Viewed Category Page', undefined, 0, true]);
+        });
+
+        it('should not track a named or categorized page when the option is off', function(){
+          ga.options.trackNamedPages = false;
+          ga.options.trackCategorizedPages = false;
+          analytics.page(null, 'Name');
+          analytics.page('Category', 'Name');
+          analytics.calledTwice(window._gaq.push);
+        });
+      });
+
+      describe('#track', function(){
+        beforeEach(function(){
+          analytics.stub(window._gaq, 'push');
+        });
+
+        it('should send an event', function(){
+          analytics.track('event');
+          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', undefined, 0, undefined]);
+        });
+
+        it('should send a category property', function(){
+          analytics.track('event', { category: 'category' });
+          analytics.called(window._gaq.push, ['_trackEvent', 'category', 'event', undefined, 0, undefined]);
+        });
+
+        it('should send a stored category', function(){
+          analytics.page('category');
+          analytics.track('event', { category: 'category' });
+          analytics.called(window._gaq.push, ['_trackEvent', 'category', 'event', undefined, 0, undefined]);
+        });
+
+        it('should send a label property', function(){
+          analytics.track('event', { label: 'label' });
+          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', 'label', 0, undefined]);
+        });
+
+        it('should send a rounded value property', function(){
+          analytics.track('event', { value: 1.1 });
+          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', undefined, 1, undefined]);
+        });
+
+        it('should prefer a rounded revenue property', function(){
+          analytics.track('event', { revenue: 9.99 });
+          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', undefined, 10, undefined]);
+        });
+
+        it('should send a non-interaction property', function(){
+          analytics.track('event', { noninteraction: true });
+          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', undefined, 0, true]);
+        });
+
+        it('should send a non-interaction option', function(){
+          analytics.track('event', {}, { 'Google Analytics': { noninteraction: true } });
+          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', undefined, 0, true]);
+        });
+      });
+
+      describe('ecommerce', function(){
+        beforeEach(function(){
+          analytics.stub(window._gaq, 'push');
+        });
+
+        it('should send simple ecommerce data', function(){
+          analytics.track('completed order', { orderId: '078781c7' });
+          analytics.assert(2 == window._gaq.push.args.length);
+          analytics.assert('_addTrans' == window._gaq.push.args[0][0][0]);
+          analytics.assert('_trackTrans' == window._gaq.push.args[1][0][0]);
+        });
+
+        it('should send ecommerce data', function(){
+          analytics.track('completed order', {
+            orderId: 'af5ccd73',
+            total: 99.99,
+            shipping: 13.99,
+            tax: 20.99,
+            products: [{
+              quantity: 1,
+              price: 24.75,
+              name: 'my product',
+              sku: 'p-298'
+            }, {
+              quantity: 3,
+              price: 24.75,
+              name: 'other product',
+              sku: 'p-299'
+            }]
+          });
+
+          analytics.deepEqual(window._gaq.push.args[0], [[
+            '_addTrans',
+            'af5ccd73',
+            undefined,
+            99.99,
+            20.99,
+            13.99,
+            undefined,
+            undefined,
+            undefined
+          ]]);
+
+          analytics.deepEqual(window._gaq.push.args[1], [[
+            '_addItem',
+            'af5ccd73',
+            'p-298',
+            'my product',
+            undefined,
+            24.75,
+            1,
+          ]]);
+
+          analytics.deepEqual(window._gaq.push.args[2], [[
+            '_addItem',
+            'af5ccd73',
+            'p-299',
+            'other product',
+            undefined,
+            24.75,
+            3
+          ]]);
+        });
+
+        it('should fallback to revenue', function(){
+          analytics.track('completed order', {
+            orderId: 'f2ffee5c',
+            revenue: 9,
+            shipping: 3,
+            tax: 2,
+            products: []
+          });
+
+          analytics.deepEqual(window._gaq.push.args[0], [[
+            '_addTrans',
+            'f2ffee5c',
+            undefined,
+            9,
+            2,
+            3,
+            undefined,
+            undefined,
+            undefined
+          ]]);
+        });
+      });
+    });
   });
-
 });


### PR DESCRIPTION
@ianstormtaylor ported the google analytics tests, but is one that isn't passing.

```
should send a stored category ‣
Error: Expected "stub" to be called with "[
  "send",
  "event",
  {
    "eventCategory": "category",
    "eventAction": "event",
    "eventValue": 0
  }
]", 
but it was called with "[
  "send",
  "pageview",
  {
    "page": "/",
    "title": "category",
    "location": "http://localhost:4202/?grep=Google%20Analytics"
  }
]".
    at module.exports.exports (http://localhost:4202/build/build.js:35717:9)
    at Analytics.analytics.called (http://localhost:4202/build/build.js:21505:5)
    at Context.<anonymous> (http://localhost:4202/build/build.js:4602:21)
    at Test.Runnable.run (http://localhost:4202/test/mocha.js:4212:32)
    at Runner.runTest (http://localhost:4202/test/mocha.js:4584:10)
    at http://localhost:4202/test/mocha.js:4630:12
    at next (http://localhost:4202/test/mocha.js:4510:14)
    at http://localhost:4202/test/mocha.js:4519:7
    at next (http://localhost:4202/test/mocha.js:4463:23)
    at http://localhost:4202/test/mocha.js:4482:7
```
