### PR TITLE
Hublo integration

### DIFF
--- a/integrations.js
+++ b/integrations.js
@@ -33,6 +33,7 @@ module.exports = [
   require('./lib/heap'),
   require('./lib/hellobar'),
   require('./lib/hittail'),
+  require('./lib/hublo'),
   require('./lib/hubspot'),
   require('./lib/improvely'),
   require('./lib/inspectlet'),

--- a/lib/hublo/index.js
+++ b/lib/hublo/index.js
@@ -1,0 +1,54 @@
+
+var integration = require('analytics.js-integration');
+var load = require('load-script');
+
+/**
+ * Expose plugin.
+ */
+
+module.exports = exports = function(analytics){
+  analytics.addIntegration(Hublo);
+};
+
+/**
+ * Expose `hublo.com` integration.
+ */
+
+var Hublo = exports.Integration = integration('Hublo')
+  .assumesPageview()
+  .readyOnInitialize()
+  .global('_hublo_')
+  .option('apiKey', null);
+
+/**
+ * Initialize.
+ *
+ * https://cdn.hublo.co/5353a2e62b26c1277b000004.js
+ *
+ * @param {Object} page
+ */
+
+Hublo.prototype.initialize = function(page){
+  this.load();
+};
+
+/**
+ * Load.
+ *
+ * @param {Function} callback
+ */
+
+Hublo.prototype.load = function(callback){
+  var url = '//cdn.hublo.co/' + this.options.apiKey + '.js';
+  load(url, callback);
+};
+
+/**
+ * Loaded?
+ *
+ * @return {Boolean}
+ */
+
+Hublo.prototype.loaded = function(){
+  return !! (window._hublo_ && typeof window._hublo_.setup === 'function');
+};

--- a/lib/hublo/test.js
+++ b/lib/hublo/test.js
@@ -1,0 +1,65 @@
+describe('Hublo', function () {
+  var analytics = require('analytics');
+  var test = require('analytics.js-integration-tester');
+  var sinon = require('sinon');
+  var assert = require('assert');
+  var Hublo = require('./index');
+
+  var hublo;
+  var settings = {
+    apiKey: '5353a2e62b26c1277b000004'
+  };
+
+  beforeEach(function () {
+    analytics.use(Hublo);
+    hublo = new Hublo.Integration(settings);
+    hublo.initialize();
+  });
+
+  it('should have the right settings', function () {
+    test(hublo)
+      .name('Hublo')
+      .assumesPageview()
+      .readyOnInitialize()
+      .global('_hublo_')
+      .option('apiKey', null);
+  });
+
+  describe('#initialize', function () {
+    beforeEach(function(){
+      sinon.spy(hublo, 'load');
+    });
+
+    it('should call #load', function (){
+      hublo.initialize();
+      assert(hublo.load.called);
+    });
+  });
+
+  describe('#loaded', function () {
+    it('should test window._hublo_.setup', function (){
+      window._hublo_ = undefined;
+      assert(!hublo.loaded());
+
+      window._hublo_ = { setup: function () {} };
+      assert(hublo.loaded());
+    });
+  });
+
+  describe('#load', function () {
+    beforeEach(function () {
+      // "Unload" Hublo
+      window._hublo_ = null;
+    });
+
+    it('should change loaded state', function (done) {
+      assert(!hublo.loaded());
+      hublo.load(function (err) {
+        if (err) return done(err);
+        assert(hublo.loaded());
+        done();
+      });
+    });
+  });
+
+});

--- a/test/index.js
+++ b/test/index.js
@@ -23,7 +23,7 @@ if ('undefined' != typeof window) {
 
 describe('integrations', function(){
   it('should export our integrations', function(){
-    assert(object.length(Integrations) === 74);
+    assert(object.length(Integrations) === 75);
   });
 });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -31,6 +31,7 @@ require('../lib/gosquared/test.js');
 require('../lib/heap/test.js');
 require('../lib/hellobar/test.js');
 require('../lib/hittail/test.js');
+require('../lib/hublo/test.js');
 require('../lib/hubspot/test.js');
 require('../lib/improvely/test.js');
 require('../lib/inspectlet/test.js');


### PR DESCRIPTION
Hi,

Here is a pull to add Hublo (https://www.hublo.com).

Actually had to fiddle a bit to make tests pass (see https://github.com/hublo/analytics.js-integrations/commit/778f9a0eb7ae4b194a3d6160122e39e94b8e4084, that I didn't include in the pull).
I suspect I wasn't supposed to, so I didn't put it in the pull, but I'll be happy to make any necessary changes.

I fail to attach the `.eps` logo within the pull ("unsupported file type"), sending it over email.

Thanks,

Léo
