### PR TITLE
trakio: port test to new api

### DIFF
--- a/lib/trakio/index.js
+++ b/lib/trakio/index.js
@@ -1,9 +1,13 @@
 
-var alias = require('alias');
-var callback = require('callback');
-var clone = require('clone');
+/**
+ * Module dependencies.
+ */
+
 var integration = require('analytics.js-integration');
+var callback = require('callback');
 var load = require('load-script');
+var alias = require('alias');
+var clone = require('clone');
 
 /**
  * Expose plugin.
@@ -19,7 +23,7 @@ module.exports = exports = function(analytics){
 
 var Trakio = exports.Integration = integration('trak.io')
   .assumesPageview()
-  .readyOnInitialize()
+  .readyOnLoad()
   .global('trak')
   .option('token', '')
   .option('trackNamedPages', true)
@@ -42,11 +46,11 @@ var optionsAliases = {
  */
 
 Trakio.prototype.initialize = function(page){
-  var self = this;
   var options = this.options;
   window.trak = window.trak || [];
   window.trak.io = window.trak.io || {};
-  window.trak.io.load = function(e){self.load(); var r = function(e){return function(){window.trak.push([e].concat(Array.prototype.slice.call(arguments,0))); }; } ,i=["initialize","identify","track","alias","channel","source","host","protocol","page_view"]; for (var s=0;s<i.length;s++) window.trak.io[i[s]]=r(i[s]); window.trak.io.initialize.apply(window.trak.io,arguments); };
+  window.trak.push = window.trak.push || function(){};
+  window.trak.io.load = window.trak.io.load || function(e){var r = function(e){return function(){window.trak.push([e].concat(Array.prototype.slice.call(arguments,0))); }; } ,i=["initialize","identify","track","alias","channel","source","host","protocol","page_view"]; for (var s=0;s<i.length;s++) window.trak.io[i[s]]=r(i[s]); window.trak.io.initialize.apply(window.trak.io,arguments); };
   window.trak.io.load(options.token, alias(options, optionsAliases));
   this.load();
 };
@@ -64,11 +68,11 @@ Trakio.prototype.loaded = function(){
 /**
  * Load the trak.io library.
  *
- * @param {Function} callback
+ * @param {Function} fn
  */
 
-Trakio.prototype.load = function(callback){
-  load('//d29p64779x43zo.cloudfront.net/v1/trak.io.min.js', callback);
+Trakio.prototype.load = function(fn){
+  load('//d29p64779x43zo.cloudfront.net/v1/trak.io.min.js', fn);
 };
 
 /**

--- a/lib/trakio/test.js
+++ b/lib/trakio/test.js
@@ -1,223 +1,211 @@
 
+var Analytics = require('analytics.js').constructor;
+var integration = require('analytics.js-integration');
+var tester = require('segmentio/analytics.js-integration-tester@1.3.0');
+var plugin = require('./');
+var tick = require('next-tick');
+var when = require('when');
+
 describe('trak.io', function(){
-
-  var analytics = require('analytics.js');
-  var assert = require('assert');
-  var each = require('each');
-  var sinon = require('sinon');
-  var test = require('analytics.js-integration-tester');
-  var Trakio = require('./index')
-  var tick = require('next-tick');
-  var when = require('when');
-
+  var Trakio = plugin.Integration;
   var trakio;
-  var settings = {
+  var analytics;
+  var options = {
     token: '740d36a79fb593bbc034a3ac934bc04f5a591c0c'
   };
 
   beforeEach(function(){
-    analytics.use(Trakio);
-    trakio = new Trakio.Integration(settings);
-    trakio.initialize(); // noop
+    analytics = new Analytics;
+    trakio = new Trakio(options);
+    analytics.use(plugin);
+    analytics.use(tester);
+    analytics.add(trakio);
   });
 
   afterEach(function(){
-    trakio.reset();
+    analytics.restore();
+    analytics.reset();
   });
 
+  after(function(){
+    trakio.reset();
+  });
+  
   it('should store the right settings', function(){
-    test(trakio)
-      .name('trak.io')
+    var Test = integration('trak.io')
       .assumesPageview()
-      .readyOnInitialize()
+      .readyOnLoad()
       .global('trak')
       .option('token', '')
       .option('trackNamedPages', true);
+
+    analytics.validate(Trakio, Test);
   });
 
-  describe('#initialize', function(){
+  describe('before loading', function(){
     beforeEach(function(){
-      trakio.load = sinon.spy();
+      analytics.stub(trakio, 'load');
     });
 
-    it('should set up the window.trak.io variables', function(){
-      trakio.initialize();
-      assert(window.trak.io);
-      assert(window.trak.io.identify);
-      assert(window.trak.io.track);
-      assert(window.trak.io.alias);
+    afterEach(function(){
+      trakio.reset();
     });
 
-    it('should call #load', function(){
-      trakio.initialize();
-      assert(trakio.load.called);
-    });
-  });
+    describe('#initialize', function(){
+      it('should set up the window.trak.io variables', function(){
+        analytics.initialize();
+        analytics.page();
+        analytics.assert(window.trak.io);
+        analytics.assert(window.trak.io.identify);
+        analytics.assert(window.trak.io.track);
+        analytics.assert(window.trak.io.alias);
+      });
 
-  describe('#loaded', function(){
-    it('should test window.trak.loaded', function(){
-      window.trak = {};
-      assert(!trakio.loaded());
-      window.trak.loaded = true;
-      assert(trakio.loaded());
-    });
-  });
-
-  describe('#load', function(){
-    beforeEach(function(){
-      sinon.stub(trakio, 'load');
-      trakio.initialize();
-      trakio.load.restore();
+      it('should call #load', function(){
+        analytics.initialize();
+        analytics.page();
+        analytics.called(trakio.load);
+      });
     });
 
-    it('should change loaded state', function (done) {
-      assert(!trakio.loaded());
-      trakio.load(function (err) {
-        if (err) return done(err);
-        // doesn't load immediately
-        when(function(){
-          return trakio.loaded();
-        }, done);
+    describe('#loaded', function(){
+      it('should test window.trak.loaded', function(){
+        window.trak = {};
+        analytics.assert(!trakio.loaded());
+        window.trak.loaded = true;
+        analytics.assert(trakio.loaded());
       });
     });
   });
 
-  describe('#page', function(){
-    beforeEach(function (done) {
-      trakio.initialize();
-      trakio.once('load', function(){
-        sinon.stub(window.trak.io, 'page_view');
-        sinon.stub(window.trak.io, 'track');
-        done();
-      });
-    });
-
-    it('should call page_view', function(){
-      test(trakio).page();
-      assert(window.trak.io.page_view.called);
-    });
-
-    it('should send a path and title', function(){
-      test(trakio).page(null, null, { path: '/path', title: 'title' });
-      assert(window.trak.io.page_view.calledWith('/path', 'title'));
-    });
-
-    it('should prefer a name', function(){
-      test(trakio).page(null, 'name', { title: 'title' });
-      assert(window.trak.io.page_view.calledWith(undefined, 'name'));
-    });
-
-    it('should prefer a category and name', function(){
-      test(trakio).page('category', 'name', { title: 'title' });
-      assert(window.trak.io.page_view.calledWith(undefined, 'category name'));
-    });
-
-    it('should track named pages by default', function(){
-      test(trakio).page(null, 'Name');
-      assert(window.trak.io.track.calledWith('Viewed Name Page'));
-    });
-
-    it('should track named pages with categories', function(){
-      test(trakio).page('Category', 'Name');
-      assert(window.trak.io.track.calledWith('Viewed Category Name Page'));
-    });
-
-    it('should track categorized pages by default', function(){
-      test(trakio).page('Category', 'Name');
-      assert(window.trak.io.track.calledWith('Viewed Category Page'));
-    });
-
-    it('should not track named or categorized pages if the option is off', function(){
-      trakio.options.trackNamedPages = false;
-      trakio.options.trackCategorizedPages = false;
-      test(trakio).page(null, 'Name');
-      test(trakio).page('Category', 'Name');
-      assert(!window.trak.io.track.called);
+  describe('loading', function(){
+    it('should load', function(done){
+      analytics.load(trakio, done);
     });
   });
 
-  describe('#identify', function(){
-    beforeEach(function (done) {
-      trakio.initialize();
-      trakio.once('load', function(){
-        window.trak.io.identify = sinon.spy();
-        done();
+  describe('after loading', function(){
+    beforeEach(function(done){
+      analytics.once('ready', done);
+      analytics.initialize();
+      analytics.page();
+    });
+
+    describe('#page', function(){
+      beforeEach(function(){
+        analytics.stub(window.trak.io, 'page_view');
+        analytics.stub(window.trak.io, 'track');
+      });
+
+      it('should call page_view', function(){
+        analytics.page();
+        analytics.called(window.trak.io.page_view);
+      });
+
+      it('should send a path and title', function(){
+        analytics.page(null, null, { path: '/path', title: 'title' });
+        analytics.called(window.trak.io.page_view, '/path', 'title');
+      });
+
+      it('should prefer a name', function(){
+        analytics.page(null, 'name', { title: 'title' });
+        analytics.called(window.trak.io.page_view, window.location.pathname, 'name');
+      });
+
+      it('should prefer a category and name', function(){
+        analytics.page('category', 'name', { title: 'title' });
+        analytics.called(window.trak.io.page_view, window.location.pathname, 'category name');
+      });
+
+      it('should track named pages by default', function(){
+        analytics.page(null, 'Name');
+        analytics.called(window.trak.io.track, 'Viewed Name Page');
+      });
+
+      it('should track named pages with categories', function(){
+        analytics.page('Category', 'Name');
+        analytics.called(window.trak.io.track, 'Viewed Category Name Page');
+      });
+
+      it('should track categorized pages by default', function(){
+        analytics.page('Category', 'Name');
+        analytics.called(window.trak.io.track, 'Viewed Category Page');
+      });
+
+      it('should not track named or categorized pages if the option is off', function(){
+        trakio.options.trackNamedPages = false;
+        trakio.options.trackCategorizedPages = false;
+        analytics.page(null, 'Name');
+        analytics.page('Category', 'Name');
+        analytics.didNotCall(window.trak.io.track);
       });
     });
 
-    it('should send id', function(){
-      test(trakio)
-        .identify('id')
-        .called(window.trak.io.identify)
-        .args('id', { id: 'id' });
-    });
-
-    it('should send traits', function(){
-      test(trakio).identify(null, { trait: true });
-      assert(window.trak.io.identify.calledWith({ trait: true }));
-    });
-
-    it('should send an id and traits', function(){
-      test(trakio)
-        .identify('id', { trait: true })
-        .called(window.trak.io.identify)
-        .args('id', { trait: true, id: 'id' });
-    });
-
-    it('should alias traits', function(){
-      test(trakio).identify(null, {
-        avatar: 'avatar',
-        firstName: 'first',
-        lastName: 'last'
+    describe('#identify', function(){
+      beforeEach(function(){
+        analytics.stub(window.trak.io, 'identify');
       });
-      assert(window.trak.io.identify.calledWith({
-        avatar_url: 'avatar',
-        first_name: 'first',
-        last_name: 'last'
-      }));
-    });
-  });
 
-  describe('#track', function(){
-    beforeEach(function (done) {
-      trakio.initialize();
-      trakio.once('load', function(){
-        window.trak.io.track = sinon.spy();
-        done();
+      it('should send id', function(){
+        analytics.identify('id');
+        analytics.called(window.trak.io.identify, 'id', { id: 'id' });
       });
-    });
 
-    it('should send an event', function(){
-      test(trakio).track('event');
-      assert(window.trak.io.track.calledWith('event'));
-    });
+      it('should send traits', function(){
+        analytics.identify(null, { trait: true });
+        analytics.called(window.trak.io.identify, { trait: true });
+      });
 
-    it('should send an event and properties', function(){
-      test(trakio).track('event', { property: true });
-      assert(window.trak.io.track.calledWith('event', { property: true }));
-    });
-  });
+      it('should send an id and traits', function(){
+        analytics.identify('id', { trait: true });
+        analytics.called(window.trak.io.identify, 'id', { trait: true, id: 'id' });
+      });
 
-  describe('#alias', function(){
-    beforeEach(function (done) {
-      trakio.initialize();
-      trakio.once('load', function(){
-        tick(function(){
-          window.trak.io.distinct_id = sinon.stub();
-          window.trak.io.alias = sinon.spy();
-          done();
+      it('should alias traits', function(){
+        analytics.identify(null, {
+          avatar: 'avatar',
+          firstName: 'first',
+          lastName: 'last'
+        });
+        analytics.called(window.trak.io.identify, {
+          avatar_url: 'avatar',
+          first_name: 'first',
+          last_name: 'last'
         });
       });
     });
 
-    it('should send a new id', function(){
-      test(trakio).alias('new');
-      assert(window.trak.io.alias.calledWith('new'));
+    describe('#track', function(){
+      beforeEach(function(){
+        analytics.stub(window.trak.io, 'track');
+      });
+
+      it('should send an event', function(){
+        analytics.track('event');
+        analytics.called(window.trak.io.track, 'event');
+      });
+
+      it('should send an event and properties', function(){
+        analytics.track('event', { property: true });
+        analytics.called(window.trak.io.track, 'event', { property: true });
+      });
     });
 
-    it('should send a new id and an original id', function(){
-      test(trakio).alias('another', 'original');
-      assert(window.trak.io.alias.calledWith('original', 'another'));
+    describe('#alias', function(){
+      beforeEach(function(){
+        analytics.stub(window.trak.io, 'distinct_id');
+        analytics.stub(window.trak.io, 'alias');
+      });
+
+      it('should send a new id', function(){
+        analytics.alias('new');
+        analytics.called(window.trak.io.alias, 'new');
+      });
+
+      it('should send a new id and an original id', function(){
+        analytics.alias('another', 'original');
+        analytics.called(window.trak.io.alias, 'original', 'another');
+      });
     });
   });
 });


### PR DESCRIPTION
/cc @ianstormtaylor there are two tests not passing, any ideas? I also had to add `window.trak.push = window.trak.push || function(){}` because of when we're reinitializing in the tests, but not reloading, the real `window.trak` object doesn't have a push method, so it fails.

```
should prefer a name ‣
Error: Expected "stub" to be called with "[
  null,
  "name"
]", 
but it was called with "[
  "/",
  "name"
]".
    at module.exports.exports (http://localhost:4202/build/build.js:260:9)
    at Analytics.analytics.called (http://localhost:4202/build/build.js:21464:5)
    at Context.<anonymous> (http://localhost:4202/build/build.js:11108:19)
    at Test.Runnable.run (http://localhost:4202/test/mocha.js:4212:32)
    at Runner.runTest (http://localhost:4202/test/mocha.js:4584:10)
    at http://localhost:4202/test/mocha.js:4630:12
    at next (http://localhost:4202/test/mocha.js:4510:14)
    at http://localhost:4202/test/mocha.js:4519:7
    at next (http://localhost:4202/test/mocha.js:4463:23)
    at http://localhost:4202/test/mocha.js:4482:7
```

```
should prefer a category and name ‣
Error: Expected "stub" to be called with "[
  null,
  "category name"
]", 
but it was called with "[
  "/",
  "category name"
]".
    at module.exports.exports (http://localhost:4202/build/build.js:260:9)
    at Analytics.analytics.called (http://localhost:4202/build/build.js:21464:5)
    at Context.<anonymous> (http://localhost:4202/build/build.js:11113:19)
    at Test.Runnable.run (http://localhost:4202/test/mocha.js:4212:32)
    at Runner.runTest (http://localhost:4202/test/mocha.js:4584:10)
    at http://localhost:4202/test/mocha.js:4630:12
    at next (http://localhost:4202/test/mocha.js:4510:14)
    at http://localhost:4202/test/mocha.js:4519:7
    at next (http://localhost:4202/test/mocha.js:4463:23)
    at http://localhost:4202/test/mocha.js:4482:7
```
