### PR TITLE
saasquatch: port tests to new api

### DIFF
--- a/lib/saasquatch/index.js
+++ b/lib/saasquatch/index.js
@@ -24,7 +24,7 @@ var SaaSquatch = exports.Integration = integration('SaaSquatch')
   .global('_sqh');
 
 /**
- * Initialize
+ * Initialize.
  *
  * @param {Page} page
  */

--- a/lib/saasquatch/test.js
+++ b/lib/saasquatch/test.js
@@ -1,75 +1,92 @@
 
+var Analytics = require('analytics.js').constructor;
+var integration = require('analytics.js-integration');
+var tester = require('segmentio/analytics.js-integration-tester@1.3.0');
+var plugin = require('./');
+
 describe('SaaSquatch', function(){
-
-  var SaaSquatch = require('./index')
-  var test = require('analytics.js-integration-tester');
-  var analytics = require('analytics.js');
-  var assert = require('assert');
-  var equal = require('equals');
-  var sinon = require('sinon');
-  var squatch;
-
-  var settings = {
+  var SaaSquatch = plugin.Integration;
+  var saasquatch;
+  var analytics;
+  var options = {
     tenantAlias: 'baz',
     accountId: 'foo'
   };
 
   beforeEach(function(){
-    analytics.use(SaaSquatch);
-    squatch = new SaaSquatch.Integration(settings);
-    squatch.initialize();
-  })
+    analytics = new Analytics;
+    saasquatch = new SaaSquatch(options);
+    analytics.use(plugin);
+    analytics.use(tester);
+    analytics.add(saasquatch);
+  });
 
   afterEach(function(){
-    squatch.reset();
-  })
+    analytics.restore();
+    analytics.reset();
+  });
 
+  after(function(){
+    saasquatch.reset();
+  });
+  
   it('should have the correct settings', function(){
-    test(squatch)
-      .name('SaaSquatch')
+    var Test = integration('SaaSquatch')
+      .readyOnInitialize()
       .option('tenantAlias', '')
       .global('_sqh');
+
+    analytics.validate(SaaSquatch, Test);
   })
 
-  describe('#loaded', function(){
-    it('should test window._sqh.push', function(){
-      window._sqh = [];
-      assert(!squatch.loaded());
-      window._sqh.push = [].slice;
-      assert(squatch.loaded());
-    })
-  })
-
-  describe('#load', function(){
+  describe('before loading', function(){
     beforeEach(function(){
-      sinon.stub(squatch, 'load');
-      squatch.initialize();
-      squatch.load.restore();
-    })
+      analytics.stub(saasquatch, 'load');
+    });
 
-    it('should change the loaded state', function(done){
-      test(squatch).loads(done);
-    })
-  })
+    afterEach(function(){
+      saasquatch.reset();
+    });
 
-  describe('#identify', function(){
-    beforeEach(function(){
-      squatch.initialize();
-      window._sqh = [];
-      window._sqh.push = sinon.spy();
-      sinon.stub(squatch, 'load');
-    })
+    describe('#loaded', function(){
+      it('should test window._sqh.push', function(){
+        window._sqh = [];
+        analytics.assert(!saasquatch.loaded());
+        window._sqh.push = [].slice;
+        analytics.assert(saasquatch.loaded());
+      });
+    });
+  });
 
-    it('should not send if userId or email are missing', function(){
-      test(squatch).identify();
-      assert(!window._sqh.push.called);
-    })
+  describe('loading', function(){
+    it('should load', function(done){
+      analytics.on('ready', done);
+      analytics.initialize();
+      analytics.page();
+      analytics.identify('my-id');
+    });
+  });
 
-    it('should send if userId is given', function(){
-      test(squatch)
-        .identify('id')
-        .called(window._sqh.push)
-        .args(['init', {
+  describe('after loading', function(){
+    beforeEach(function(done){
+      analytics.once('ready', done);
+      analytics.initialize();
+      analytics.page();
+    });
+
+    describe('#identify', function(){
+      beforeEach(function(){
+        analytics.stub(window._sqh, 'push');
+      });
+
+      it('should not send if userId or email are missing', function(){
+        analytics.identify();
+        analytics.didNotCall(window._sqh.push);
+      });
+
+      it('should send if userId is given', function(){
+        analytics.identify('id');
+        analytics.called(window._sqh.push, ['init', {
           user_id: 'id',
           tenant_alias: 'baz',
           email: undefined,
@@ -77,27 +94,23 @@ describe('SaaSquatch', function(){
           last_name: undefined,
           user_image: undefined
         }]);
-    })
+      });
 
-    it('should send if email is given', function(){
-      test(squatch)
-        .identify(null, { email: 'self@example.com' })
-        .called(window._sqh.push)
-        .args(['init', {
+      it('should send if email is given', function(){
+        analytics.identify(null, { email: 'self@example.com' });
+        analytics.called(window._sqh.push, ['init', {
           user_id: null,
           tenant_alias: 'baz',
           email: 'self@example.com',
           first_name: undefined,
           last_name: undefined,
           user_image: undefined
-        }])
-    })
+        }]);
+      });
 
-    it('should pass checksum', function(){
-      test(squatch)
-        .identify(null, { email: 'self@example.com' }, { SaaSquatch: { checksum: 'wee' } })
-        .called(window._sqh.push)
-        .args(['init', {
+      it('should pass checksum', function(){
+        analytics.identify(null, { email: 'self@example.com' }, { SaaSquatch: { checksum: 'wee' } });
+        analytics.called(window._sqh.push, ['init', {
           user_id: null,
           tenant_alias: 'baz',
           email: 'self@example.com',
@@ -105,14 +118,12 @@ describe('SaaSquatch', function(){
           last_name: undefined,
           user_image: undefined,
           checksum: 'wee'
-        }])
-    })
+        }]);
+      });
 
-    it('should pass accountId', function(){
-      test(squatch)
-        .identify(null, { email: 'self@example.com', accountId: 123 })
-        .called(window._sqh.push)
-        .args(['init', {
+      it('should pass accountId', function(){
+        analytics.identify(null, { email: 'self@example.com', accountId: 123 });
+        analytics.called(window._sqh.push, ['init', {
           user_id: null,
           tenant_alias: 'baz',
           email: 'self@example.com',
@@ -120,14 +131,12 @@ describe('SaaSquatch', function(){
           last_name: undefined,
           user_image: undefined,
           account_id: 123
-        }])
-    })
+        }]);
+      });
 
-    it('should pass referral image', function(){
-      test(squatch)
-        .identify(1, { referralImage: 'img' })
-        .called(window._sqh.push)
-        .args(['init', {
+      it('should pass referral image', function(){
+        analytics.identify(1, { referralImage: 'img' });
+        analytics.called(window._sqh.push, ['init', {
           user_id: 1,
           tenant_alias: 'baz',
           email: undefined,
@@ -135,19 +144,14 @@ describe('SaaSquatch', function(){
           last_name: undefined,
           user_image: undefined,
           fb_share_image: 'img'
-        }])
-    })
+        }]);
+      });
 
-    it('should send only once', function(){
-      test(squatch).identify('id');
-      test(squatch).identify('id');
-      assert(window._sqh.push.calledOnce);
-    })
-
-    it('should call #load after identify', function(){
-      window._sqh = [];
-      test(squatch).identify('my-id');
-      assert(squatch.load.called);
-    })
-  })
-})
+      it('should send only once', function(){
+        analytics.identify('id');
+        analytics.identify('id');
+        analytics.calledOnce(window._sqh.push);
+      });
+    });
+  });
+});


### PR DESCRIPTION
/cc @ianstormtaylor here is a case where `.load` is probably used in a weird way. basically it's implemented so `.load` is only called on `identify`. but maybe either we put that `.load` into initialize, or we load the script inside `identify` but don't call it `load`.
