### PR TITLE
bugsnag: port tests

### DIFF
--- a/lib/bugsnag/test.js
+++ b/lib/bugsnag/test.js
@@ -1,111 +1,87 @@
 
+var Analytics = require('analytics.js').constructor;
+var integration = require('analytics.js-integration');
+var tester = require('segmentio/analytics.js-integration-tester@1.3.0');
+var plugin = require('./');
+
 describe('Bugsnag', function(){
-
-  var analytics = require('analytics.js');
-  var assert = require('assert');
-  var Bugsnag = require('./index')
-  var equal = require('equals');
-  var sinon = require('sinon');
-  var test = require('analytics.js-integration-tester');
-
+  var Bugsnag = plugin.Integration;
   var bugsnag;
-  var settings = {
+  var analytics;
+  var options = {
     apiKey: 'x'
   };
 
-  // HACK: bugsnag overrides, setTimeout
-  // it doesn't break tests but since those
-  // tests load bugsnag <script> multiple
-  // times so that break things.
-  var so, si;
-  before(function(){
-    so = window.setTimeout;
-    si = window.setInterval;
-  })
-
-  after(function(){
-    window.setTimeout = so;
-    window.setInterval = si;
-  })
-
   beforeEach(function(){
-    analytics.use(Bugsnag);
-    bugsnag = new Bugsnag.Integration(settings);
+    analytics = new Analytics;
+    bugsnag = new Bugsnag(options);
+    analytics.use(plugin);
+    analytics.use(tester);
+    analytics.add(bugsnag);
   });
 
   afterEach(function(){
+    analytics.restore();
+    analytics.reset();
+  });
+
+  after(function(){
     bugsnag.reset();
   });
 
-  it('should have the right settings', function(){
-    test(bugsnag)
-      .name('Bugsnag')
-      .readyOnLoad()
-      .global('Bugsnag')
-      .option('apiKey', '');
-  });
-
-  describe('#initialize', function(){
+  describe('before loading', function(){
     beforeEach(function(){
-      sinon.stub(bugsnag, 'load');
+      analytics.stub(bugsnag, 'load');
     });
 
-    it('should call #load', function(){
-      bugsnag.initialize();
-      assert(bugsnag.load.called);
-    });
-  });
-
-  describe('#loaded', function(){
-    it('should test window.Bugsnag', function(){
-      assert(!bugsnag.loaded());
-      window.Bugsnag = document.createElement('div');
-      assert(!bugsnag.loaded());
-      window.Bugsnag = {};
-      assert(bugsnag.loaded());
-    });
-  });
-
-  describe('#load', function(){
-    beforeEach(function(){
-      sinon.stub(bugsnag, 'load');
-      bugsnag.initialize();
-      bugsnag.load.restore();
+    afterEach(function(){
+      bugsnag.reset();
     });
 
-    it('should change loaded state', function (done) {
-      assert(!bugsnag.loaded());
-      bugsnag.load(function (err) {
-        if (err) return done(err);
-        assert(bugsnag.loaded());
-        window.Bugsnag.notify('baz');
-        done();
+
+    it('should have the right settings', function(){
+      analytics.validate(Bugsnag, integration('Bugsnag')
+        .readyOnLoad()
+        .global('Bugsnag')
+        .option('apiKey', ''));
+    });
+
+    describe('#initialize', function(){
+      it('should call #load', function(){
+        analytics.initialize();
+        analytics.called(bugsnag.load);
       });
     });
+  });
 
-    it('should set an onerror handler', function (done) {
-      var handler = window.onerror;
-      bugsnag.load(function (err) {
+  describe('loading', function(){
+    it('should load and set an onerror handler', function(done){
+      var onerror = window.onerror;
+      analytics.load(bugsnag, function(err){
         if (err) return done(err);
-        assert(handler !== window.onerror);
-        assert('function' === typeof window.onerror);
+        analytics.notEqual(window.onerror, onerror);
+        analytics.equal('function', typeof window.onerror);
         done();
       });
     });
   });
 
-  describe('#identify', function(){
-    beforeEach(function (done) {
-      bugsnag.initialize();
-      bugsnag.once('load', done);
+  describe('after loading', function(){
+    beforeEach(function(done){
+      analytics.once('ready', done);
+      analytics.initialize();
+      analytics.page();
     });
 
-    it('should set metadata', function(){
-      test(bugsnag)
-      .identify('id', { trait: true })
-      .changed(window.Bugsnag.metaData)
-      .to({ id: 'id', trait: true });
+    describe('#identify', function(){
+      it('should set metadata', function(){
+        analytics.identify('id', { trait: true });
+        debugger;
+        analytics.deepEqual(window.Bugsnag.metaData, {
+          id: 'id',
+          trait: true
+        });
+      });
     });
   });
-
 });


### PR DESCRIPTION
cc @lancejpollard 

i changed the `validate` call to make it terser, but also because i forgot to add the actual comparison check in appcues, so this forces us to add it this way?

we should probably change it back to `compare` since its really comparing two objects and not validating like the tester was
