### PR TITLE
livechat: port tests to new api

### DIFF
--- a/lib/livechat/index.js
+++ b/lib/livechat/index.js
@@ -1,8 +1,12 @@
 
-var each = require('each');
+/**
+ * Module dependencies.
+ */
+
 var integration = require('analytics.js-integration');
 var load = require('load-script');
 var clone = require('clone');
+var each = require('each');
 var when = require('when');
 
 /**

--- a/lib/livechat/test.js
+++ b/lib/livechat/test.js
@@ -1,35 +1,40 @@
 
+var Analytics = require('analytics.js').constructor;
+var integration = require('analytics.js-integration');
+var tester = require('segmentio/analytics.js-integration-tester@1.3.0');
+var timeouts = require('clear-timeouts');
+var intervals = require('clear-intervals');
+var plugin = require('./');
+
 describe('LiveChat', function(){
-
-  var timeouts = require('clear-timeouts');
-  var intervals = require('clear-intervals');
-  var analytics = require('analytics.js');
-  var assert = require('assert');
-  var equal = require('equals');
-  var LiveChat = require('./index')
-  var sinon = require('sinon');
-  var test = require('analytics.js-integration-tester');
-
+  var LiveChat = plugin.Integration;
   var livechat;
-  var settings = {
+  var analytics;
+  var options = {
     license: '4293371'
   };
 
   beforeEach(function(){
-    analytics.use(LiveChat);
-    livechat = new LiveChat.Integration(settings);
-    livechat.initialize(); // noop
+    analytics = new Analytics;
+    livechat = new LiveChat(options);
+    analytics.use(plugin);
+    analytics.use(tester);
+    analytics.add(livechat);
   });
 
   afterEach(function(){
+    analytics.restore();
+    analytics.reset();
     timeouts();
     intervals();
-    livechat.reset();
   });
 
+  after(function(){
+    livechat.reset();
+  });
+  
   it('should have the right settings', function(){
-    test(livechat)
-      .name('LiveChat')
+    var Test = integration('LiveChat')
       .assumesPageview()
       .readyOnLoad()
       .global('__lc')
@@ -37,85 +42,86 @@ describe('LiveChat', function(){
       .global('LC_Invite')
       .global('__lc_inited')
       .option('license', '');
+
+    analytics.validate(LiveChat, Test);
   });
 
-  describe('#initialize', function(){
+  describe('before loading', function(){
     beforeEach(function(){
-      livechat.load = sinon.spy();
+      analytics.stub(livechat, 'load');
     });
 
-    it('should create window.__lc', function(){
-      assert(!window.__lc);
-      livechat.initialize();
-      assert(equal(window.__lc, { license: settings.license, group: 0 }));
+    afterEach(function(){
+      livechat.reset();
     });
 
-    it('should call #load', function(){
-      livechat.initialize();
-      assert(livechat.load.called);
-    });
-  });
+    describe('#initialize', function(){
+      it('should create window.__lc', function(){
+        analytics.assert(!window.__lc);
+        analytics.initialize();
+        analytics.page();
+        analytics.deepEqual(window.__lc, { license: options.license, group: 0 });
+      });
 
-  describe('#loaded', function(){
-    it('should test .isLoaded', function(){
-      assert(!livechat.loaded());
-      window.LC_API = {};
-      assert(!livechat.loaded());
-      window.LC_Invite = {};
-      assert(livechat.loaded());
-    });
-  });
-
-  describe('#load', function(){
-    beforeEach(function(){
-      sinon.stub(livechat, 'load');
-      livechat.initialize();
-      livechat.load.restore();
+      it('should call #load', function(){
+        analytics.initialize();
+        analytics.page();
+        analytics.called(livechat.load);
+      });
     });
 
-    it('should change loaded state', function (done) {
-      if (livechat.loaded()) return done(new Error('livechat already loaded'));
-      livechat.load(function (err) {
-        if (err) return done(err);
-        assert(livechat.loaded());
-        done();
+    describe('#loaded', function(){
+      it('should test .isLoaded', function(){
+        analytics.assert(!livechat.loaded());
+        window.LC_API = {};
+        analytics.assert(!livechat.loaded());
+        window.LC_Invite = {};
+        analytics.assert(livechat.loaded());
       });
     });
   });
 
-  describe('#identify', function(){
-    beforeEach(function (done) {
-      livechat.initialize();
-      livechat.once('ready', function(){
-        sinon.spy(window.LC_API, 'set_custom_variables');
-        window.LC_API.set_custom_variables.reset();
-        done();
-      });
-    });
-
-    it('should send an id', function(){
-      test(livechat).identify('id');
-      assert(window.LC_API.set_custom_variables.calledWith([
-        { name: 'id', value: 'id' },
-        { name: 'User ID', value: 'id' }
-      ]));
-    });
-
-    it('should send traits', function(){
-      test(livechat).identify(null, { trait: true });
-      assert(window.LC_API.set_custom_variables.calledWith([
-        { name: 'trait', value: 'true' }
-      ]));
-    });
-
-    it('should send an id and traits', function(){
-      test(livechat).identify('id', { trait: true });
-      assert(window.LC_API.set_custom_variables.calledWith([
-        { name: 'trait', value: 'true' },
-        { name: 'id', value: 'id' },
-        { name: 'User ID',value: 'id' }
-      ]));
+  describe('loading', function(){
+    it('should load', function(done){
+      analytics.load(livechat, done);
     });
   });
 
+  describe('after loading', function(){
+    beforeEach(function(done){
+      analytics.once('ready', done);
+      analytics.initialize();
+      analytics.page();
+    });
+
+    describe('#identify', function(){
+      beforeEach(function(){
+        analytics.stub(window.LC_API, 'set_custom_variables');
+      });
+
+      it('should send an id', function(){
+        analytics.identify('id');
+        analytics.called(window.LC_API.set_custom_variables, [
+          { name: 'id', value: 'id' },
+          { name: 'User ID', value: 'id' }
+        ]);
+      });
+
+      it('should send traits', function(){
+        analytics.identify(null, { trait: true });
+        analytics.called(window.LC_API.set_custom_variables, [
+          { name: 'trait', value: 'true' }
+        ]);
+      });
+
+      it('should send an id and traits', function(){
+        analytics.identify('id', { trait: true });
+        analytics.called(window.LC_API.set_custom_variables, [
+          { name: 'trait', value: 'true' },
+          { name: 'id', value: 'id' },
+          { name: 'User ID',value: 'id' }
+        ]);
+      });
+    });
+  });
 });


### PR DESCRIPTION
/cc @ianstormtaylor getting this error on the last 2 tests, where `true` is not being converted to `'true'`, any ideas? what is the desired behavior / what should we do here?

``` js
Error: Expected "stub" to be called with "[
  [
    {
      "name": "trait",
      "value": "true"
    }
  ]
]", 
but it was called with "[
  [
    {
      "name": "trait",
      "value": true
    }
  ]
]".
    at module.exports.exports (http://localhost:4202/build/build.js:260:9)
    at Analytics.analytics.called (http://localhost:4202/build/build.js:21581:5)
    at Context.<anonymous> (http://localhost:4202/build/build.js:7807:19)
    at Test.require.register.Runnable.run (http://localhost:4202/test/mocha.js:4212:32)
    at Runner.require.register.Runner.runTest (http://localhost:4202/test/mocha.js:4584:10)
    at http://localhost:4202/test/mocha.js:4630:12
    at next (http://localhost:4202/test/mocha.js:4510:14)
    at http://localhost:4202/test/mocha.js:4519:7
    at next (http://localhost:4202/test/mocha.js:4463:23)
    at http://localhost:4202/test/mocha.js:4482:7
```
