### PR TITLE
chartbeat: port tests, update mocha

### DIFF
--- a/lib/chartbeat/test.js
+++ b/lib/chartbeat/test.js
@@ -1,153 +1,123 @@
 
+var Analytics = require('analytics.js').constructor;
+var extend = require('extend');
+var integration = require('analytics.js-integration');
+var tester = require('segmentio/analytics.js-integration-tester@1.3.0');
+var plugin = require('./');
+
 describe('Chartbeat', function () {
-
-  var analytics = require('analytics.js');
-  var assert = require('assert');
-  var Chartbeat = require('./index')
-  var defaults = require('defaults');
-  var equal = require('equals');
-  var sinon = require('sinon');
-  var test = require('analytics.js-integration-tester');
-
+  var Chartbeat = plugin.Integration;
   var chartbeat;
-
-  // Custom settings passed to constructor.
-  var settings = {
+  var analytics;
+  var options = {
     uid: 'x',
     domain: 'example.com'
   };
 
-  beforeEach(function () {
-    analytics.use(Chartbeat);
-    chartbeat = new Chartbeat.Integration(settings);
-    chartbeat.initialize();
+  beforeEach(function(){
+    analytics = new Analytics;
+    chartbeat = new Chartbeat(options);
+    analytics.use(plugin);
+    analytics.use(tester);
+    analytics.add(chartbeat);
   });
 
   afterEach(function(){
+    analytics.restore();
+    analytics.reset();
+  });
+
+  after(function(){
     chartbeat.reset();
   });
 
-  it('should have the right settings', function(){
-    test(chartbeat)
-      .name('Chartbeat')
-      .assumesPageview()
-      .readyOnLoad()
-      .global('_sf_async_config')
-      .global('_sf_endpt')
-      .global('pSUPERFLY')
-      .option('domain', '')
-      .option('uid', null);
-  });
-
-  describe('#initialize', function(){
+  describe('before loading', function(){
     beforeEach(function(){
-      chartbeat.load = sinon.spy();
+      analytics.stub(chartbeat, 'load');
     });
 
     afterEach(function(){
-      window._sf_async_config = undefined;
+      chartbeat.reset();
     });
 
-    it('should create window._sf_async_config', function(){
-      chartbeat.initialize();
-      var expected = defaults(settings, { useCanonical: true });
-      assert(equal(window._sf_async_config, expected));
+    it('should have the right settings', function(){
+      analytics.validate(Chartbeat, integration('Chartbeat')
+        .assumesPageview()
+        .readyOnLoad()
+        .global('_sf_async_config')
+        .global('_sf_endpt')
+        .global('pSUPERFLY')
+        .option('domain', '')
+        .option('uid', null));
     });
 
-    it('should inherit global window._sf_async_config defaults', function(){
-      window._sf_async_config = {
-        sponsorName: 'exampleSponsor',
-        authors: 'exampleAuthors'
-      };
-      chartbeat.initialize();
-      var expected = defaults(settings, window._sf_async_config, {
-        useCanonical: true
+    describe('#initialize', function(){
+      it('should create window._sf_async_config', function(){
+        var expected = extend({}, options, { useCanonical: true });
+        analytics.initialize();
+        analytics.page();
+        analytics.deepEqual(window._sf_async_config, expected);
       });
-      assert(equal(window._sf_async_config, expected));
-    });
 
-    it('should allow overriding global window._sf_async_config', function(){
-      window._sf_async_config = {
-        sponsorName: 'exampleSponsor',
-        authors: 'exampleAuthors'
-      };
-      chartbeat.initialize({
-        sponsorName: 'overrideSponsor'
+      it('should inherit global window._sf_async_config defaults', function(){
+        window._sf_async_config = { setting: true };
+        var expected = extend({}, options, {
+          setting: true,
+          useCanonical: true
+        });
+
+        analytics.initialize();
+        analytics.page();
+        analytics.deepEqual(window._sf_async_config, expected);
       });
-      var expected = defaults(settings, window._sf_async_config, {
-        useCanonical: true,
-        sponsorName: 'overrideSponsor'
+
+      it('should create window._sf_endpt', function(){
+        analytics.assert(!window._sf_endpt);
+        analytics.initialize();
+        analytics.page();
+        analytics.equal('number', typeof window._sf_endpt);
       });
-      assert(equal(window._sf_async_config, expected));
-    });
 
-    it('should call #load', function(){
-      chartbeat.initialize();
-      assert(chartbeat.load.called);
-    });
-
-    it('should create window._sf_endpt', function(){
-      chartbeat.initialize();
-      assert('number' === typeof window._sf_endpt);
-    });
-
-    it('should call #load', function(){
-      chartbeat.initialize();
-      assert(chartbeat.load.called);
-    });
-  });
-
-  describe('#loaded', function(){
-    it('should test window.pSUPERFLY', function(){
-      assert(!chartbeat.loaded());
-      window.pSUPERFLY = {};
-      assert(chartbeat.loaded());
-    });
-  });
-
-  describe('#load', function(){
-    beforeEach(function (){
-      sinon.stub(chartbeat, 'load');
-      chartbeat.initialize();
-      chartbeat.load.restore();
-    });
-
-    it('should change loaded state', function(done){
-      assert(!chartbeat.loaded());
-      chartbeat.load(function (err) {
-        if (err) return done(err);
-        assert(chartbeat.loaded());
-        done();
+      it('should call #load', function(){
+        analytics.initialize();
+        analytics.page();
+        analytics.called(chartbeat.load);
       });
     });
   });
 
-  describe('#page', function(){
-    beforeEach(function(){
-      chartbeat.initialize();
-      window.pSUPERFLY = { virtualPage: sinon.spy() };
-    });
-
-    it('should send a path and title', function(){
-      test(chartbeat)
-        .page(null, null, { path: '/path', title: 'title' })
-        .called(window.pSUPERFLY.virtualPage)
-        .args('/path', 'title');
-    });
-
-    it('should prefer a name', function(){
-      test(chartbeat)
-        .page(null, 'name', { path: '/path', title: 'title' })
-        .called(window.pSUPERFLY.virtualPage)
-        .args('/path', 'name');
-    });
-
-    it('should prefer a name and category', function(){
-      test(chartbeat)
-        .page('category', 'name', { path: '/path', title: 'title' })
-        .called(window.pSUPERFLY.virtualPage)
-        .args('/path', 'category name');
+  describe('loading', function(){
+    it('should load', function(done){
+      analytics.load(chartbeat, done);
     });
   });
 
+  describe('after loading', function(){
+    beforeEach(function(done){
+      analytics.once('ready', done);
+      analytics.initialize();
+      analytics.page();
+    });
+
+    describe('#page', function(){
+      beforeEach(function(){
+        analytics.stub(window.pSUPERFLY, 'virtualPage');
+      });
+
+      it('should send a path and title', function(){
+        analytics.page({ path: '/path', title: 'title' });
+        analytics.called(window.pSUPERFLY.virtualPage, '/path', 'title');
+      });
+
+      it('should prefer a name', function(){
+        analytics.page('Name', { path: '/path', title: 'title' });
+        analytics.called(window.pSUPERFLY.virtualPage, '/path', 'Name');
+      });
+
+      it('should prefer a name and category', function(){
+        analytics.page('Category', 'Name', { path: '/path', title: 'title' });
+        analytics.called(window.pSUPERFLY.virtualPage, '/path', 'Category Name');
+      });
+    });
+  });
 });

--- a/test/mocha.css
+++ b/test/mocha.css
@@ -132,6 +132,7 @@ body {
   color: #c00;
   max-height: 300px;
   overflow: auto;
+  white-space: pre-wrap;
 }
 
 #mocha .test pre {


### PR DESCRIPTION
removed the `'should allow overriding global window._sf_async_config'` test because it wasn't testing what it said it was, if we ever want to make the logic actually do that we can add the test in

cc @lancejpollard 
