### PR TITLE
Adds optional page support to frontleaf integration

### DIFF
--- a/lib/frontleaf/index.js
+++ b/lib/frontleaf/index.js
@@ -27,7 +27,9 @@ var Frontleaf = exports.Integration = integration('Frontleaf')
   .global('_flBaseUrl')
   .option('baseUrl', 'https://api.frontleaf.com')
   .option('token', '')
-  .option('stream', '');
+  .option('stream', '')
+  .option('trackNamedPages', false)
+  .option('trackCategorizedPages', false);
 
 /**
  * Initialize.
@@ -98,6 +100,28 @@ Frontleaf.prototype.group = function(group){
       name: group.proxy('traits.name'),
       data: clean(group.traits())
     });
+  }
+};
+
+/**
+ * Page.
+ *
+ * @param {Page} page
+ */
+
+Frontleaf.prototype.page = function(page){
+  var category = page.category();
+  var name = page.fullName();
+  var opts = this.options;
+
+  // categorized pages
+  if (category && opts.trackCategorizedPages) {
+    this.track(page.track(category));
+  }
+
+  // named pages
+  if (name && opts.trackNamedPages) {
+    this.track(page.track(name));
   }
 };
 

--- a/lib/frontleaf/test.js
+++ b/lib/frontleaf/test.js
@@ -38,7 +38,9 @@ describe('Frontleaf', function(){
       .global('_fl')
       .global('_flBaseUrl')
       .option('token', '')
-      .option('stream', ''));
+      .option('stream', '')
+      .option('trackNamedPages', false)
+      .option('trackCategorizedPages', false));
   });
 
   describe('before loading', function(){
@@ -163,6 +165,40 @@ describe('Frontleaf', function(){
           name: 'name',
           data: {}
         });
+      });
+    });
+
+    describe('#page', function(){
+      beforeEach(function(){
+        analytics.stub(frontleaf, '_push');
+      });
+
+      it('should not track anonymous pages by default', function(){
+        analytics.page();
+        analytics.didNotCall(frontleaf._push);
+      });
+
+      it('should track named pages when the option is on', function(){
+        frontleaf.options.trackNamedPages = true;
+        analytics.page('Name');
+        analytics.didNotCall(frontleaf._push, 'event', 'Viewed Category Page');
+        analytics.called(frontleaf._push, 'event', 'Viewed Name Page');
+      });
+
+      it('should track named pages with categories when the options are on', function(){
+        frontleaf.options.trackNamedPages = true;
+        frontleaf.options.trackCategorizedPages = true;
+        analytics.page('Category', 'Name');
+        analytics.didNotCall(frontleaf._push, 'event', 'Viewed Name Page');
+        analytics.called(frontleaf._push, 'event', 'Viewed Category Page');
+        analytics.called(frontleaf._push, 'event', 'Viewed Category Name Page');
+      });
+
+      it('should track categorized pages when the option is on', function(){
+        frontleaf.options.trackCategorizedPages = true;
+        analytics.page('Category', 'Name');
+        analytics.didNotCall(frontleaf._push, 'event', 'Viewed Name Page');
+        analytics.called(frontleaf._push, 'event', 'Viewed Category Page');
       });
     });
 


### PR DESCRIPTION
Note that this adds two new optional settings (`trackNamedPages` and `trackCategorizedPages`), essentially the same as MixPanel's implementation.
