### PR TITLE
Add/array support

### DIFF
--- a/lib/adroll/index.js
+++ b/lib/adroll/index.js
@@ -6,6 +6,7 @@
 var integration = require('segmentio/analytics.js-integration');
 var snake = require('to-snake-case');
 var useHttps = require('use-https');
+var each = require('each');
 var is = require('is');
 
 /**
@@ -24,11 +25,11 @@ var AdRoll = module.exports = integration('AdRoll')
   .global('adroll_adv_id')
   .global('adroll_pix_id')
   .global('adroll_custom_data')
-  .option('events', {})
   .option('advId', '')
   .option('pixId', '')
   .tag('http', '<script src="http://a.adroll.com/j/roundtrip.js">')
-  .tag('https', '<script src="https://s.adroll.com/j/roundtrip.js">');
+  .tag('https', '<script src="https://s.adroll.com/j/roundtrip.js">')
+  .mapping('events');
 
 /**
  * Initialize.
@@ -77,23 +78,28 @@ AdRoll.prototype.page = function(page){
  */
 
 AdRoll.prototype.track = function(track){
-  var events = this.options.events;
   var event = track.event();
-  var data = {};
   var user = this.analytics.user();
-  if (user.id()) data.user_id = user.id();
+  var events = this.events(event);
+  var total = track.revenue() || track.total() || 0;
+  var orderId = track.orderId() || 0;
 
-  if (has.call(events, event)) {
-    event = events[event];
-    var total = track.revenue() || track.total() || 0;
-    var orderId = track.orderId() || 0;
+  each(events, function(event){
+    var data = {};
+    if (user.id()) data.user_id = user.id();
     data.adroll_conversion_value_in_dollars = total;
     data.order_id = orderId;
+    // the adroll interface only allows for
+    // segment names which are snake cased.
+    data.adroll_segments = snake(event);
+    window.__adroll.record_user(data);
+  });
+
+  // no events found
+  if (!events.length) {
+    var data = {};
+    if (user.id()) data.user_id = user.id();
+    data.adroll_segments = snake(event);
+    window.__adroll.record_user(data);
   }
-
-  // the adroll interface only allows for 
-  // segment names which are snake cased.
-  data.adroll_segments = snake(event);
-
-  window.__adroll.record_user(data);
 };

--- a/lib/adroll/test.js
+++ b/lib/adroll/test.js
@@ -37,7 +37,8 @@ describe('AdRoll', function(){
       .global('adroll_pix_id')
       .global('adroll_custom_data')
       .option('advId', '')
-      .option('pixId', ''));
+      .option('pixId', '')
+      .mapping('events'));
   });
 
   describe('before loading', function(){
@@ -200,6 +201,23 @@ describe('AdRoll', function(){
             user_id: 'id'
           });
         });
+
+        it('should support array events', function(){
+          adroll.options.events = [{ key: 'event', value: 'pixel' }];
+          analytics.track('event', { total: 2.99, orderId: 2 });
+          analytics.called(window.__adroll.record_user, {
+            adroll_segments: 'pixel',
+            adroll_conversion_value_in_dollars: 2.99,
+            order_id: 2
+          });
+        });
+
+        it('should track multiple events', function(){
+          adroll.options.events = [{ key: 'event', value: 'one' }];
+          adroll.options.events.push({ key: 'event', value: 'two' });
+          analytics.track('event', { total: 2.99, orderId: 2 });
+          analytics.calledTwice(window.__adroll.record_user);
+        })
       });
     });
   });

--- a/lib/adwords/index.js
+++ b/lib/adwords/index.js
@@ -7,6 +7,7 @@ var integration = require('segmentio/analytics.js-integration');
 var onbody = require('on-body');
 var domify = require('domify');
 var Queue = require('queue');
+var each = require('each');
 
 /**
  * HOP
@@ -27,8 +28,8 @@ var q = new Queue({ concurrency: 1, timeout: 2000 });
 var AdWords = module.exports = integration('AdWords')
   .option('conversionId', '')
   .option('remarketing', false)
-  .option('events', {})
-  .tag('conversion', '<script src="//www.googleadservices.com/pagead/conversion.js">');
+  .tag('conversion', '<script src="//www.googleadservices.com/pagead/conversion.js">')
+  .mapping('events');
 
 /**
  * Load.
@@ -75,13 +76,15 @@ AdWords.prototype.page = function(page){
 
 AdWords.prototype.track = function(track){
   var id = this.options.conversionId;
-  var events = this.options.events;
-  var event = track.event();
-  if (!has.call(events, event)) return;
-  return this.conversion({
-    value: track.revenue() || 0,
-    label: events[event],
-    conversionId: id
+  var events = this.events(track.event());
+  var revenue = track.revenue() || 0;
+  var self = this;
+  each(events, function(label){
+    self.conversion({
+      conversionId: id,
+      value: revenue,
+      label: label,
+    });
   });
 };
 

--- a/lib/adwords/test.js
+++ b/lib/adwords/test.js
@@ -37,7 +37,7 @@ describe('AdWords', function(){
     analytics.compare(AdWords, integration('AdWords')
       .option('conversionId', '')
       .option('remarketing', false)
-      .option('events', {}));
+      .mapping('events'));
   });
 
   describe('after loading', function(){
@@ -111,6 +111,16 @@ describe('AdWords', function(){
           conversionId: adwords.options.conversionId,
           label: adwords.options.events.signup,
           value: 0,
+        });
+      });
+
+      it('should support array events', function(){
+        adwords.options.events = [{ key: 'login', value: 'QbThCM_zogcQofXB0gM' }];
+        analytics.track('login');
+        analytics.called(adwords.conversion, {
+          conversionId: adwords.options.conversionId,
+          label: adwords.options.events[0].value,
+          value: 0
         });
       });
 

--- a/lib/awesm/index.js
+++ b/lib/awesm/index.js
@@ -4,6 +4,7 @@
  */
 
 var integration = require('segmentio/analytics.js-integration');
+var each = require('each');
 
 /**
  * Expose `Awesm` integration.
@@ -13,8 +14,8 @@ var Awesm = module.exports = integration('awe.sm')
   .assumesPageview()
   .global('AWESM')
   .option('apiKey', '')
-  .option('events', {})
-  .tag('<script src="//widgets.awe.sm/v3/widgets.js?key={{ apiKey }}&async=true">');
+  .tag('<script src="//widgets.awe.sm/v3/widgets.js?key={{ apiKey }}&async=true">')
+  .mapping('events');
 
 /**
  * Initialize.
@@ -46,9 +47,9 @@ Awesm.prototype.loaded = function(){
  */
 
 Awesm.prototype.track = function(track){
-  var event = track.event();
-  var goal = this.options.events[event];
-  if (!goal) return;
   var user = this.analytics.user();
-  window.AWESM.convert(goal, track.cents(), null, user.id());
+  var goals = this.events(track.event());
+  each(goals, function(goal){
+    window.AWESM.convert(goal, track.cents(), null, user.id());
+  });
 };

--- a/lib/awesm/test.js
+++ b/lib/awesm/test.js
@@ -36,7 +36,7 @@ describe('awe.sm', function(){
       .assumesPageview()
       .global('AWESM')
       .option('apiKey', '')
-      .option('events', {}));
+      .mapping('events'));
   });
 
   describe('before loading', function(){
@@ -85,6 +85,12 @@ describe('awe.sm', function(){
       it('should not convert an unknown event', function(){
         analytics.track('unknown');
         analytics.didNotCall(window.AWESM.convert);
+      });
+
+      it('should support array events', function(){
+        awesm.options.events = [{ key: 'event', value: 'goal_2' }];
+        analytics.track('event', { value: 2 });
+        analytics.called(window.AWESM.convert, 'goal_2', 2);
       });
 
       it('should accept a value property', function(){

--- a/lib/bing-ads/index.js
+++ b/lib/bing-ads/index.js
@@ -9,6 +9,7 @@ var domify = require('domify');
 var extend = require('extend');
 var bind = require('bind');
 var when = require('when');
+var each = require('each');
 
 /**
  * HOP.
@@ -17,7 +18,7 @@ var when = require('when');
 var has = Object.prototype.hasOwnProperty;
 
 /**
- * 
+ * Noop.
  */
 
 var noop = function(){};
@@ -31,8 +32,8 @@ var noop = function(){};
 var Bing = module.exports = integration('Bing Ads')
   .option('siteId', '')
   .option('domainId', '')
-  .option('events', {})
-  .tag('<script id="mstag_tops" src="//flex.msn.com/mstag/site/{{ siteId }}/mstag.js">');
+  .tag('<script id="mstag_tops" src="//flex.msn.com/mstag/site/{{ siteId }}/mstag.js">')
+  .mapping('events');
 
 /**
  * Initialize.
@@ -85,18 +86,17 @@ Bing.prototype.loaded = function(){
  */
 
 Bing.prototype.track = function(track){
-  var events = this.options.events;
-  var traits = track.traits();
-  var event = track.event();
-  if (!has.call(events, event)) return;
-  var goal = events[event];
+  var events = this.events(track.event());
   var revenue = track.revenue() || 0;
-  window.mstag.loadTag('analytics', {
-    domainId: this.options.domainId,
-    revenue: revenue,
-    dedup: '1',
-    type: '1',
-    actionid: goal
+  var self = this;
+  each(events, function(goal){
+    window.mstag.loadTag('analytics', {
+      domainId: self.options.domainId,
+      revenue: revenue,
+      dedup: '1',
+      type: '1',
+      actionid: goal
+    });
   });
 };
 
@@ -114,7 +114,7 @@ function writeToAppend(str) {
   // https://github.com/component/domify/issues/14
   if ('script' == el.tagName.toLowerCase() && el.getAttribute('src')) {
     var tmp = document.createElement('script');
-    tmp.src = el.getAttribute('src'); 
+    tmp.src = el.getAttribute('src');
     tmp.async = true;
     el = tmp;
   }

--- a/lib/bing-ads/test.js
+++ b/lib/bing-ads/test.js
@@ -37,8 +37,8 @@ describe('Bing Ads', function(){
   it('should have the correct settings', function(){
     analytics.compare(Bing, integration('Bing Ads')
       .option('siteId', '')
-      .option('events', {})
-      .option('domainId', ''));
+      .option('domainId', '')
+      .mapping('events'));
   });
 
   describe('loading', function(){
@@ -72,6 +72,18 @@ describe('Bing Ads', function(){
           dedup: '1',
           type: '1',
           actionid: options.events.play
+        });
+      });
+
+      it('should support array events', function(){
+        bing.options.events = [{ key: 'event', value: 4 }];
+        analytics.track('event', { revenue: 99 });
+        analytics.called(window.mstag.loadTag, 'analytics', {
+          actionid: bing.options.events[0].value,
+          domainId: options.domainId,
+          revenue: 99,
+          dedup: '1',
+          type: '1'
         });
       });
     });

--- a/lib/churnbee/index.js
+++ b/lib/churnbee/index.js
@@ -3,8 +3,9 @@
  * Module dependencies.
  */
 
-var push = require('global-queue')('_cbq');
 var integration = require('segmentio/analytics.js-integration');
+var push = require('global-queue')('_cbq');
+var each = require('each');
 
 /**
  * HOP
@@ -33,9 +34,9 @@ var supported = {
 var ChurnBee = module.exports = integration('ChurnBee')
   .global('_cbq')
   .global('ChurnBee')
-  .option('events', {})
   .option('apiKey', '')
-  .tag('<script src="//api.churnbee.com/cb.js">');
+  .tag('<script src="//api.churnbee.com/cb.js">')
+  .mapping('events');
 
 /**
  * Initialize.
@@ -67,9 +68,11 @@ ChurnBee.prototype.loaded = function(){
  */
 
 ChurnBee.prototype.track = function(track){
-  var events = this.options.events;
   var event = track.event();
-  if (has.call(events, event)) event = events[event];
-  if (true != supported[event]) return;
-  push(event, track.properties({ revenue: 'amount' }));
+  var events = this.events(event);
+  events.push(event);
+  each(events, function(event){
+    if (true != supported[event]) return;
+    push(event, track.properties({ revenue: 'amount' }));
+  });
 };

--- a/lib/churnbee/test.js
+++ b/lib/churnbee/test.js
@@ -35,7 +35,8 @@ describe('ChurnBee', function(){
     analytics.compare(ChurnBee, integration('ChurnBee')
       .global('_cbq')
       .global('ChurnBee')
-      .option('apiKey', ''));
+      .option('apiKey', '')
+      .mapping('events'));
   });
 
   describe('before loading', function(){
@@ -96,6 +97,12 @@ describe('ChurnBee', function(){
         analytics.track('Logged In');
         analytics.called(window._cbq.push, ['login', {}]);
       });
+
+      it('should support array events', function(){
+        churnbee.options.events = [{ key: 'event', value: 'login' }];
+        analytics.track('event');
+        analytics.called(window._cbq.push, ['login', {}]);
+      })
 
       it('should alias `revenue` to `amount`', function(){
         analytics.track('register', { revenue: 90 });

--- a/lib/facebook-ads/index.js
+++ b/lib/facebook-ads/index.js
@@ -5,6 +5,7 @@
 
 var integration = require('segmentio/analytics.js-integration');
 var push = require('global-queue')('_fbq');
+var each = require('each');
 
 /**
  * HOP
@@ -19,8 +20,8 @@ var has = Object.prototype.hasOwnProperty;
 var Facebook = module.exports = integration('Facebook Ads')
   .global('_fbq')
   .option('currency', 'USD')
-  .option('events', {})
-  .tag('<script src="//connect.facebook.net/en_US/fbds.js">');
+  .tag('<script src="//connect.facebook.net/en_US/fbds.js">')
+  .mapping('events');
 
 /**
  * Initialize Facebook Ads.
@@ -55,18 +56,20 @@ Facebook.prototype.loaded = function(){
  */
 
 Facebook.prototype.track = function(track){
-  var events = this.options.events;
-  var traits = track.traits();
   var event = track.event();
+  var events = this.events(event);
   var revenue = track.revenue() || 0;
-  var data = track.properties();
-  if (has.call(events, event)) {
-    // conversion flow
-    event = events[event];
-    data = {
+  var self = this;
+
+  each(events, function(event){
+    push('track', event, {
       value: String(revenue.toFixed(2)),
-      currency: this.options.currency
-    };
+      currency: self.options.currency
+    });
+  });
+
+  if (!events.length) {
+    var data = track.properties();
+    push('track', event, data);
   }
-  push('track', event, data);
 };

--- a/lib/facebook-ads/test.js
+++ b/lib/facebook-ads/test.js
@@ -35,7 +35,7 @@ describe('Facebook Ads', function(){
   it('should have the correct settings', function(){
     analytics.compare(Facebook, integration('Facebook Ads')
       .option('currency', 'USD')
-      .option('events', {}));
+      .mapping('events'));
   });
 
   describe('loading', function(){
@@ -66,7 +66,16 @@ describe('Facebook Ads', function(){
         analytics.called(window._fbq.push, [ 'track', 0, {
           currency: 'USD',
           value: '0.00'
-        } ]);
+        }]);
+      });
+
+      it('should support array events', function(){
+        facebook.options.events = [{ key: 'event', value: 4 }];
+        analytics.track('event');
+        analytics.called(window._fbq.push, ['track', 4, {
+          currency: 'USD',
+          value: '0.00'
+        }]);
       });
 
       it('should send revenue', function(){

--- a/lib/twitter-ads/index.js
+++ b/lib/twitter-ads/index.js
@@ -4,6 +4,7 @@
  */
 
 var integration = require('segmentio/analytics.js-integration');
+var each = require('each');
 
 /**
  * HOP.
@@ -16,8 +17,8 @@ var has = Object.prototype.hasOwnProperty;
  */
 
 var TwitterAds = module.exports = integration('Twitter Ads')
-  .option('events', {})
-  .tag('pixel', '<img src="//analytics.twitter.com/i/adsct?txn_id={{ event }}&p_id=Twitter"/>');
+  .tag('pixel', '<img src="//analytics.twitter.com/i/adsct?txn_id={{ event }}&p_id=Twitter"/>')
+  .mapping('events');
 
 /**
  * Initialize.
@@ -36,10 +37,11 @@ TwitterAds.prototype.initialize = function(){
  */
 
 TwitterAds.prototype.track = function(track){
-  var events = this.options.events;
-  var event = track.event();
-  if (!has.call(events, event)) return;
-  return this.load('pixel', {
-    event: events[event]
+  var events = this.events(track.event());
+  var self = this;
+  each(events, function(event){
+    var el = self.load('pixel', {
+      event: event
+    });
   });
 };

--- a/lib/twitter-ads/test.js
+++ b/lib/twitter-ads/test.js
@@ -34,14 +34,13 @@ describe('Twitter Ads', function(){
 
   it('should have the correct settings', function(){
     analytics.compare(Twitter, integration('Twitter Ads')
-      .option('events', {}));
+      .mapping('events'));
   });
 
   describe('after loading', function(){
     beforeEach(function(done){
       analytics.once('ready', done);
       analytics.initialize();
-      
       analytics.page();
     });
 
@@ -58,6 +57,12 @@ describe('Twitter Ads', function(){
       it('should send correctly', function(){
         analytics.track('play');
         analytics.loaded('<img src="http://analytics.twitter.com/i/adsct?txn_id=e3196de1&p_id=Twitter">');
+      });
+
+      it('should support array events', function(){
+        twitter.options.events = [{ key: 'event', value: 12 }];
+        analytics.track('event');
+        analytics.loaded('<img src="http://analytics.twitter.com/i/adsct?txn_id=12&p_id=Twitter">')
       });
     });
   });


### PR DESCRIPTION
adds support for arrays as `options.evens`, for example:

``` js
events = [
  { key: 'event', value: 1 },
  { key: 'event', value: 2 }
];
```

in this case doing `.track('event')` will track twice, once for `1` and then for `2`.

cc @ianstormtaylor @lancejpollard 
