### PR TITLE
fix environment between tests so they reliably pass

### DIFF
--- a/lib/bugherd/index.js
+++ b/lib/bugherd/index.js
@@ -4,6 +4,7 @@
  */
 
 var integration = require('segmentio/analytics.js-integration');
+var tick = require('next-tick');
 
 /**
  * Expose `BugHerd` integration.
@@ -27,7 +28,10 @@ var BugHerd = module.exports = integration('BugHerd')
 
 BugHerd.prototype.initialize = function(page){
   window.BugHerdConfig = { feedback: { hide: !this.options.showFeedbackTab }};
-  this.load(this.ready);
+  var ready = this.ready;
+  this.load(function(){
+    tick(ready);
+  });
 };
 
 /**

--- a/lib/bugherd/test.js
+++ b/lib/bugherd/test.js
@@ -26,6 +26,8 @@ describe('BugHerd', function(){
     analytics.reset();
     bugherd.reset();
     sandbox();
+    var iframe = document.getElementById('_BH_frame');
+    if (iframe) iframe.parentNode.removeChild(iframe);
   });
 
   it('should have the right settings', function(){
@@ -40,10 +42,6 @@ describe('BugHerd', function(){
   describe('before loading', function(){
     beforeEach(function(){
       analytics.stub(bugherd, 'load');
-    });
-
-    afterEach(function(){
-      bugherd.reset();
     });
 
     describe('#initialize', function(){

--- a/lib/frontleaf/index.js
+++ b/lib/frontleaf/index.js
@@ -4,6 +4,8 @@
  */
 
 var integration = require('segmentio/analytics.js-integration');
+var bind = require('bind');
+var when = require('when');
 var is = require('is');
 
 /**
@@ -34,6 +36,8 @@ Frontleaf.prototype.initialize = function(page){
   window._flBaseUrl = window._flBaseUrl || this.options.baseUrl;
   this._push('setApiToken', this.options.token);
   this._push('setStream', this.options.stream);
+  var loaded = bind(this, this.loaded);
+  var ready = this.ready;
   this.load({ baseUrl: window._flBaseUrl }, this.ready);
 };
 
@@ -44,7 +48,7 @@ Frontleaf.prototype.initialize = function(page){
  */
 
 Frontleaf.prototype.loaded = function(){
-  return is.array(window._fl) && window._fl.ready === true ;
+  return is.array(window._fl) && window._fl.ready === true;
 };
 
 /**

--- a/lib/vero/index.js
+++ b/lib/vero/index.js
@@ -5,6 +5,7 @@
 
 var integration = require('segmentio/analytics.js-integration');
 var push = require('global-queue')('_veroq');
+var cookie = require('component/cookie');
 
 /**
  * Expose `Vero` integration.
@@ -24,6 +25,8 @@ var Vero = module.exports = integration('Vero')
  */
 
 Vero.prototype.initialize = function(page){
+  // clear default cookie so vero parses correctly.
+  if (!cookie('__veroc4')) cookie('__veroc4', '[]');
   push('init', { api_key: this.options.apiKey });
   this.load(this.ready);
 };

--- a/lib/vero/index.js
+++ b/lib/vero/index.js
@@ -26,6 +26,10 @@ var Vero = module.exports = integration('Vero')
 
 Vero.prototype.initialize = function(page){
   // clear default cookie so vero parses correctly.
+  // this is for the tests.
+  // basically, they have window.addEventListener('unload')
+  // which then saves their "command_store", which is an array.
+  // so we just want to create that initially so we can reload the tests.
   if (!cookie('__veroc4')) cookie('__veroc4', '[]');
   push('init', { api_key: this.options.apiKey });
   this.load(this.ready);

--- a/lib/vero/test.js
+++ b/lib/vero/test.js
@@ -11,7 +11,7 @@ describe('Vero', function(){
   var vero;
   var analytics;
   var options = {
-    apiKey: 'x'
+    apiKey: '99504fea17d9b70805e470a672af1c5b608eb88f'
   };
 
   beforeEach(function(){

--- a/lib/yandex-metrica/index.js
+++ b/lib/yandex-metrica/index.js
@@ -38,7 +38,9 @@ Yandex.prototype.initialize = function(page){
   var loaded = bind(this, this.loaded);
   var ready = this.ready;
   this.load(function(){
-    when(loaded, ready);
+    when(loaded, function(){
+      tick(ready);
+    });
   });
 };
 

--- a/lib/yandex-metrica/test.js
+++ b/lib/yandex-metrica/test.js
@@ -66,6 +66,12 @@ describe('Yandex', function(){
   });
 
   describe('after loading', function(){
+    beforeEach(function(done){
+      analytics.once('ready', done);
+      analytics.initialize();
+      analytics.page();
+    });
+    
     it('should create a yaCounter object', function(){
       tick(function(){
         analytics.assert(window['yaCounter' + yandex.options.counterId]);

--- a/test/clear-cookies.js
+++ b/test/clear-cookies.js
@@ -1,0 +1,17 @@
+
+/**
+ * Module dependencies.
+ */
+
+var cookie = require('component/cookie');
+
+/**
+ * Clear cookies.
+ */
+
+module.exports = function(){
+  var cookies = cookie();
+  for (var name in cookies) {
+    cookie(name, '', { path: '/' });
+  }
+};

--- a/test/clear-images.js
+++ b/test/clear-images.js
@@ -1,0 +1,66 @@
+
+/**
+ * Module dependencies.
+ */
+
+var inherit = require('component/inherit');
+
+/**
+ * Created images.
+ */
+
+var images = [];
+
+/**
+ * Keep track of original `Image`.
+ */
+
+var Original = window.Image;
+
+/**
+ * Image override that keeps track of images.
+ *
+ * Careful though, `img instance Override` isn't true.
+ */
+
+function Override() {
+  var img = new Original;
+  images.push(img);
+  return img;
+}
+
+/**
+ * Clear `onload` for each image.
+ */
+
+exports = module.exports = function(){
+  var noop = function(){};
+  for (var i = 0, n = images.length; i < n; i++) {
+    images[i].onload = noop;
+  }
+  images.length = 0;
+};
+
+/**
+ * Override `window.Image` to keep track of images,
+ * so we can clear `onload`.
+ */
+
+exports.bind = function(){
+  window.Image = Override;
+};
+
+/**
+ * Set `window.Image` back to normal.
+ */
+
+exports.unbind = function(){
+  window.Image = Original;
+  images.length = 0;
+};
+
+/**
+ * Automatically override.
+ */
+
+exports.bind();

--- a/test/clear-scripts.js
+++ b/test/clear-scripts.js
@@ -1,0 +1,25 @@
+
+/**
+ * Module dependencies.
+ */
+
+var query = require('component/query');
+var each = require('component/each');
+var indexOf = require('component/indexof');
+
+/**
+ * Initial scripts.
+ */
+
+var initialScripts = query.all('script');
+
+module.exports = function(){
+  var finalScripts = query.all('script');
+  each(finalScripts, function(script){
+    if (-1 === indexOf(initialScripts, script)) {
+      if (script.parentNode) {
+        script.parentNode.removeChild(script);
+      }
+    }
+  });
+};

--- a/test/sandbox.js
+++ b/test/sandbox.js
@@ -7,6 +7,9 @@ var clearTimeouts = require('clear-timeouts');
 var clearIntervals = require('clear-intervals');
 var clearListeners = require('./clear-listeners');
 var clearGlobals = require('./clear-globals');
+var clearImages = require('./clear-images');
+var clearScripts = require('./clear-scripts');
+var clearCookies = require('./clear-cookies');
 
 /**
  * Reset initial state.
@@ -17,4 +20,7 @@ module.exports = function(){
   clearIntervals();
   clearListeners();
   clearGlobals();
+  clearImages();
+  clearScripts();
+  clearCookies();
 };


### PR DESCRIPTION
/cc @ianstormtaylor @yields all the tests pass now in phantomjs. it all came down to fully clearing the environment between tests:
- clear cookies
- clear images
- clear scripts
### clear cookies

this could be a lot cleaner, not 100% sure how this even works, the component/cookie module is kind of wonky
### clear images

this works
### clear scripts

this seems to work in phantom, but it doesn't get rid of the errors in chrome when a jsonp file loads a script and calls a variable that has been deleted. in phantomjs, deleting the script seems to stop the script from executing which is perfect! but not sure how this will work in other browsers. but it's a decent solution for now.

thoughts?
