### PR TITLE
Fix/https

### DIFF
--- a/component.json
+++ b/component.json
@@ -58,6 +58,7 @@
     "segmentio/analytics.js": "*",
     "segmentio/analytics.js-integration-tester": "1.4.x",
     "segmentio/clear-env": "*",
+    "segmentio/location-stub": "*",
     "segmentio/spy": "*",
     "segmentio/when": "*",
     "visionmedia/mocha": "*",

--- a/lib/bronto/test.js
+++ b/lib/bronto/test.js
@@ -4,6 +4,7 @@ var integration = require('analytics.js-integration');
 var tester = require('analytics.js-integration-tester');
 var plugin = require('./');
 var sandbox = require('clear-env');
+var location = require('location-stub');
 
 describe('Bronto', function(){
   var Bronto = plugin;
@@ -26,6 +27,7 @@ describe('Bronto', function(){
     analytics.reset();
     bronto.reset();
     sandbox();
+    location.reset();
   });
 
   it('should have the correct settings', function(){
@@ -53,6 +55,14 @@ describe('Bronto', function(){
           bronto.debug,
           'missing tracking URL parameters `_bta_tid` and `_bta_c`.'
         );
+      });
+
+      it('should not warn if _bta_tid and _bta_c are found', function(){
+        location.search += '&_bta_tid=abc&bta_c=123';
+        analytics.debug();
+        analytics.initialize();
+        analytics.page();
+        analytics.didNotCall(bronto.debug, 'missing tracking URL parameters `_bta_tid` and `_bta_c`.');
       });
     });
   });

--- a/lib/clicktale/test.js
+++ b/lib/clicktale/test.js
@@ -4,6 +4,11 @@ var integration = require('analytics.js-integration');
 var tester = require('analytics.js-integration-tester');
 var plugin = require('./');
 var sandbox = require('clear-env');
+var location = require('location-stub');
+// check if <= IE8.
+// TODO: make into component?
+var modern = false;
+try { modern = !!Object.defineProperty({}, 'foo', {}); } catch (e) {}
 
 describe('ClickTale', function(){
   var ClickTale = plugin;
@@ -28,6 +33,7 @@ describe('ClickTale', function(){
     analytics.reset();
     clicktale.reset();
     sandbox();
+    location.reset();
   });
 
   it('should have the right settings', function(){
@@ -64,9 +70,18 @@ describe('ClickTale', function(){
   });
 
   describe('loading', function(){
-    it('should load', function(done){
+    it('should load http', function(done){
       analytics.load(clicktale, done);
     });
+
+    if (modern) {
+      it('should load https', function(done){
+        analytics.assert(!clicktale.options.httpsCdnUrl);
+        location.protocol = 'https:';
+        clicktale.options.httpsCdnUrl = 'http://s.clicktale.net/WRe0.js';
+        analytics.load(clicktale, done);
+      });
+    }
   });
 
   describe('after loading', function(){


### PR DESCRIPTION
@amir @ianstormtaylor This is the general idea for writing tests for URL params and https. Thoughts?

The main thing is, if we want `make test-sauce` to include running on IE8, then we will just have to wrap any tests that _won't work on <= IE8_ in `if (modern) { ... }` type thing. That's not ideal, but having these tests makes us more certain that we are covering all cases, and if it works in all browsers that we're testing (chrome, IE9+, firefox, etc.) then we can be pretty sure it works on IE8 as well because all we're doing is testing _reading_ values from `window.location`, not anything too fancy.

If we wanted all tests to run everywhere including IE8, then we would have to run the https and query param tests in a new browser window, which would mean even more changing how we write tests haha. So this seems like a reasonable compromise.
