### PR TITLE
bronto: remove generic `track` method, for #361

### DIFF
--- a/lib/bronto/index.js
+++ b/lib/bronto/index.js
@@ -55,35 +55,6 @@ Bronto.prototype.loaded = function(){
 };
 
 /**
- * Track.
- *
- * The JS conversion tracking toggles must be on
- * in the application in order for you to see the data
- * in your account, and for it to function as it should.
- * If the toggle is not on the system will ignore
- * any requests coming into it.
- *
- * To create a test user, create a contact in Bronto,
- * send that contact an email, then process through your site
- * to place a test order to hit the JS code.
- *
- * Provided you have Click Through Link Tracking enabled,
- * when a contact clicks a link contained in an email you send them via Bronto,
- * we create a tracking cookie (most commonly used for tracking conversions).
- *
- * https://app.bronto.com/mail/help/help_view/?k=mail:home:api_tracking:tracking_url_parameters
- *
- * @param {Track} event
- */
-
-Bronto.prototype.track = function(track){
-  var revenue = track.revenue();
-  var event = track.event();
-  var type = 'number' == typeof revenue ? '$' : 't';
-  this.bta.addConversionLegacy(type, event, revenue);
-};
-
-/**
  * Completed order.
  *
  * The cookie is used to link the order being processed back to the delivery,

--- a/lib/bronto/test.js
+++ b/lib/bronto/test.js
@@ -70,23 +70,7 @@ describe('Bronto', function(){
       analytics.page();
     });
 
-    describe('#track', function(){
-      beforeEach(function(){
-        analytics.stub(bronto.bta, 'addConversionLegacy');
-      });
-
-      it('should send event', function(){
-        analytics.track('some-event');
-        analytics.called(bronto.bta.addConversionLegacy, 't', 'some-event', undefined);
-      });
-
-      it('should send $ if revenue is ok', function(){
-        analytics.track('some-event', { revenue: 50 });
-        analytics.called(bronto.bta.addConversionLegacy, '$', 'some-event', 50);
-      });
-    });
-
-    describe('ecommerce', function(){
+    describe('#completedOrder', function(){
       beforeEach(function(){
         analytics.stub(bronto.bta, 'addOrder');
       });


### PR DESCRIPTION
As it stands now, bronto is only being used for tracking "completed order". So the integration is only going to support that for now. If we run into a new use case for bronto, we can go from there, but it makes more sense just to implement only what's necessary atm (if the integration is a little more difficult to figure out).

/cc @chiplay @calvinfo 
