### PR TITLE
twitter-ads: add option to track page views

### DIFF
--- a/lib/twitter-ads/index.js
+++ b/lib/twitter-ads/index.js
@@ -17,7 +17,7 @@ var has = Object.prototype.hasOwnProperty;
  */
 
 var TwitterAds = module.exports = integration('Twitter Ads')
-  .option('pagePixel', '')
+  .option('page', '')
   .tag('<img src="//analytics.twitter.com/i/adsct?txn_id={{ pixelId }}&p_id=Twitter"/>')
   .mapping('events');
 
@@ -38,8 +38,8 @@ TwitterAds.prototype.initialize = function(){
  */
 
 TwitterAds.prototype.page = function(page){
-  if (this.options.pagePixel) {
-    this.load({ pixelId: this.options.pagePixel });
+  if (this.options.page) {
+    this.load({ pixelId: this.options.page });
   }
 };
 

--- a/lib/twitter-ads/index.js
+++ b/lib/twitter-ads/index.js
@@ -17,7 +17,8 @@ var has = Object.prototype.hasOwnProperty;
  */
 
 var TwitterAds = module.exports = integration('Twitter Ads')
-  .tag('pixel', '<img src="//analytics.twitter.com/i/adsct?txn_id={{ event }}&p_id=Twitter"/>')
+  .option('pagePixel', '')
+  .tag('<img src="//analytics.twitter.com/i/adsct?txn_id={{ pixelId }}&p_id=Twitter"/>')
   .mapping('events');
 
 /**
@@ -31,6 +32,18 @@ TwitterAds.prototype.initialize = function(){
 };
 
 /**
+ * Page.
+ *
+ * @param {Page} page
+ */
+
+TwitterAds.prototype.page = function(page){
+  if (this.options.pagePixel) {
+    this.load({ pixelId: this.options.pagePixel });
+  }
+};
+
+/**
  * Track.
  *
  * @param {Track} track
@@ -39,9 +52,7 @@ TwitterAds.prototype.initialize = function(){
 TwitterAds.prototype.track = function(track){
   var events = this.events(track.event());
   var self = this;
-  each(events, function(event){
-    var el = self.load('pixel', {
-      event: event
-    });
+  each(events, function(pixelId){
+    self.load({ pixelId: pixelId });
   });
 };

--- a/lib/twitter-ads/test.js
+++ b/lib/twitter-ads/test.js
@@ -34,6 +34,7 @@ describe('Twitter Ads', function(){
 
   it('should have the correct settings', function(){
     analytics.compare(Twitter, integration('Twitter Ads')
+      .option('page', '')
       .mapping('events'));
   });
 
@@ -49,13 +50,13 @@ describe('Twitter Ads', function(){
         analytics.spy(twitter, 'load');
       });
 
-      it('should not send if pagePixel is not defined', function(){
+      it('should not send if `page` option is not defined', function(){
         analytics.page();
         analytics.didNotCall(twitter.load);
       });
 
-      it('should send if pagePixel is defined', function(){
-        twitter.options.pagePixel = 'e3196de1';
+      it('should send if `page` option is defined', function(){
+        twitter.options.page = 'e3196de1';
         analytics.page();
         analytics.loaded('<img src="http://analytics.twitter.com/i/adsct?txn_id=e3196de1&p_id=Twitter">');
       });

--- a/lib/twitter-ads/test.js
+++ b/lib/twitter-ads/test.js
@@ -44,6 +44,23 @@ describe('Twitter Ads', function(){
       analytics.page();
     });
 
+    describe('#page', function(){
+      beforeEach(function(){
+        analytics.spy(twitter, 'load');
+      });
+
+      it('should not send if pagePixel is not defined', function(){
+        analytics.page();
+        analytics.didNotCall(twitter.load);
+      });
+
+      it('should send if pagePixel is defined', function(){
+        twitter.options.pagePixel = 'e3196de1';
+        analytics.page();
+        analytics.loaded('<img src="http://analytics.twitter.com/i/adsct?txn_id=e3196de1&p_id=Twitter">');
+      });
+    });
+
     describe('#track', function(){
       beforeEach(function(){
         analytics.spy(twitter, 'load');


### PR DESCRIPTION
/cc @reinpk @DirtyAnalytics basically, you can specify a pixel to use for tracking pages
