### PR TITLE
google-analytics: fix user id field

### DIFF
--- a/lib/google-analytics/index.js
+++ b/lib/google-analytics/index.js
@@ -106,7 +106,7 @@ GA.prototype.initialize = function(){
 
   // send global id
   if (opts.sendUserId && user.id()) {
-    window.ga('set', '&uid', user.id());
+    window.ga('set', 'userId', user.id());
   }
 
   // anonymize after initializing, otherwise a warning is shown


### PR DESCRIPTION
I don't think `&uid` is supported anymore, so let's rename according to the documentation.

https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#userId
