### PR TITLE
Mixpanel/register

### DIFF
--- a/lib/mixpanel/index.js
+++ b/lib/mixpanel/index.js
@@ -134,7 +134,7 @@ Mixpanel.prototype.identify = function(identify){
   // traits
   var traits = identify.traits(traitAliases);
   if (traits.$created) del(traits, 'createdAt');
-  window.mixpanel.register(traits);
+  window.mixpanel.register(dates(traits, iso));
   if (this.options.people) window.mixpanel.people.set(traits);
 };
 

--- a/lib/mixpanel/test.js
+++ b/lib/mixpanel/test.js
@@ -184,11 +184,11 @@ describe('Mixpanel', function(){
           phone: 'phone'
         });
         analytics.called(window.mixpanel.register, {
-          $created: date,
+          $created: iso(date),
           $email: 'name@example.com',
           $first_name: 'first',
           $last_name: 'last',
-          $last_seen: date,
+          $last_seen: iso(date),
           $name: 'name',
           $username: 'username',
           $phone: 'phone'

--- a/lib/mixpanel/test.js
+++ b/lib/mixpanel/test.js
@@ -287,8 +287,10 @@ describe('Mixpanel', function(){
         mixpanel.options.increments = ['event'];
         mixpanel.options.people = true;
         analytics.track('event');
+        var date = window.mixpanel.people.set.args[0][1];
+        analytics.assert(date.getTime() == new Date().getTime());
         analytics.called(window.mixpanel.people.increment, 'event');
-        analytics.called(window.mixpanel.people.set, 'Last event', new Date);
+        analytics.called(window.mixpanel.people.set, 'Last event', date);
       });
 
       it('should convert arrays to a length number', function(){

--- a/lib/mixpanel/test.js
+++ b/lib/mixpanel/test.js
@@ -113,13 +113,13 @@ describe('Mixpanel', function(){
         analytics.called(window.mixpanel.track, 'Viewed Category Page');
       });
 
-      // it('should not track category pages when the option is off', function(){
-      //   mixpanel.options.trackNamedPages = false;
-      //   mixpanel.options.trackCategorizedPages = false;
-      //   analytics.page('Name');
-      //   analytics.page('Category', 'Name');
-      //   analytics.didNotCall(window.mixpanel.track);
-      // });
+      it('should not track category pages when the option is off', function(){
+        mixpanel.options.trackNamedPages = false;
+        mixpanel.options.trackCategorizedPages = false;
+        analytics.page('Name');
+        analytics.page('Category', 'Name');
+        analytics.didNotCall(window.mixpanel.track);
+      });
     });
 
     describe('#identify', function(){

--- a/test/index.js
+++ b/test/index.js
@@ -23,7 +23,7 @@ if ('undefined' != typeof window) {
 
 describe('integrations', function(){
   it('should export our integrations', function(){
-    assert(object.length(Integrations) === 76);
+    assert.equal(75, object.length(Integrations));
   });
 });
 


### PR DESCRIPTION
`mixpanel.register({ $created: new Date })` doesn't work for some reason, mixpanel sends it as `{}` 0_o
1. `mixpanel.register({ $created: new Date })`

![mixpanel - meh](https://cloud.githubusercontent.com/assets/1661587/3908249/eda7eb42-2301-11e4-941a-14c9be0d0931.png)
1. `mixpanel.register({ $created: new Date().toISOString() });`

![screen shot 2014-08-13 at 6 49 35 pm](https://cloud.githubusercontent.com/assets/1661587/3908261/025fcd5c-2302-11e4-904d-7930fffd948f.png)
1. `analytics.identify(id, { created: new Date })`.

![analytics](https://cloud.githubusercontent.com/assets/1661587/3908267/11b6fbc2-2302-11e4-9b13-e1ed21a4d874.png)

cc @sperand-io @ianstormtaylor @DirtyAnalytics 
