### PR TITLE
ga: removing ecommerce.js from require call

### DIFF
--- a/lib/google-analytics/index.js
+++ b/lib/google-analytics/index.js
@@ -209,7 +209,7 @@ GA.prototype.completedOrder = function(track){
 
   // require ecommerce
   if (!this.ecommerce) {
-    window.ga('require', 'ecommerce', 'ecommerce.js');
+    window.ga('require', 'ecommerce');
     this.ecommerce = true;
   }
 


### PR DESCRIPTION
Seems like it has been removed?

https://developers.google.com/analytics/devguides/collection/analyticsjs/ecommerce#loadit

@ianstormtaylor @lancejpollard 
