### PR TITLE
fix olark phantom track/page calls

### DIFF
--- a/lib/olark/index.js
+++ b/lib/olark/index.js
@@ -26,7 +26,7 @@ var Olark = module.exports = integration('Olark')
  * http://www.olark.com/documentation
  * https://www.olark.com/documentation/javascript/api.chat.setOperatorGroup
  *
- * @param {Object} page
+ * @param {Facade} page
  */
 
 Olark.prototype.initialize = function(page){
@@ -37,14 +37,11 @@ Olark.prototype.initialize = function(page){
 
   // assign chat to a specific site
   var groupId = this.options.groupId;
-  if (groupId) {
-    chat('setOperatorGroup', { group: groupId });
-  }
+  if (groupId) api('chat.setOperatorGroup', { group: groupId });
 
   // keep track of the widget's open state
-  var self = this;
-  box('onExpand', function(){ self._open = true; });
-  box('onShrink', function(){ self._open = false; });
+  api('box.onExpand', function(){ self._open = true; });
+  api('box.onShrink', function(){ self._open = false; });
 };
 
 /**
@@ -65,39 +62,31 @@ Olark.prototype.loaded = function(){
 
 Olark.prototype.load = function(callback){
   var el = document.getElementById('olark');
-  //if (!el) {
-    window.olark||(function(c){var f=window,d=document,l=https()?"https:":"http:",z=c.name,r="load";var nt=function(){f[z]=function(){(a.s=a.s||[]).push(arguments)};var a=f[z]._={},q=c.methods.length;while (q--) {(function(n){f[z][n]=function(){f[z]("call",n,arguments)}})(c.methods[q])}a.l=c.loader;a.i=nt;a.p={ 0:+new Date() };a.P=function(u){a.p[u]=new Date()-a.p[0]};function s(){a.P(r);f[z](r)}f.addEventListener?f.addEventListener(r,s,false):f.attachEvent("on"+r,s);var ld=function(){function p(hd){hd="head";return ["<",hd,"></",hd,"><",i,' onl' + 'oad="var d=',g,";d.getElementsByTagName('head')[0].",j,"(d.",h,"('script')).",k,"='",l,"//",a.l,"'",'"',"></",i,">"].join("")}var i="body",m=d[i];if (!m) {return setTimeout(ld,100)}a.P(1);var j="appendChild",h="createElement",k="src",n=d[h]("div"),v=n[j](d[h](z)),b=d[h]("iframe"),g="document",e="domain",o;n.style.display="none";m.insertBefore(n,m.firstChild).id=z;b.frameBorder="0";b.id=z+"-loader";if (/MSIE[ ]+6/.test(navigator.userAgent)) {b.src="javascript:false"}b.allowTransparency="true";v[j](b);try {b.contentWindow[g].open()}catch (w) {c[e]=d[e];o="javascript:var d="+g+".open();d.domain='"+d.domain+"';";b[k]=o+"void(0);"}try {var t=b.contentWindow[g];t.write(p());t.close()}catch (x) {b[k]=o+'d.write("'+p().replace(/"/g,String.fromCharCode(92)+'"')+'");d.close();'}a.P(2)};ld()};nt()})({ loader: "static.olark.com/jsclient/loader0.js", name:"olark", methods:["configure","extend","declare","identify"] });
-    window.olark.identify(this.options.siteId);
-  //}
+  window.olark||(function(c){var f=window,d=document,l=https()?"https:":"http:",z=c.name,r="load";var nt=function(){f[z]=function(){(a.s=a.s||[]).push(arguments)};var a=f[z]._={},q=c.methods.length;while (q--) {(function(n){f[z][n]=function(){f[z]("call",n,arguments)}})(c.methods[q])}a.l=c.loader;a.i=nt;a.p={ 0:+new Date() };a.P=function(u){a.p[u]=new Date()-a.p[0]};function s(){a.P(r);f[z](r)}f.addEventListener?f.addEventListener(r,s,false):f.attachEvent("on"+r,s);var ld=function(){function p(hd){hd="head";return ["<",hd,"></",hd,"><",i,' onl' + 'oad="var d=',g,";d.getElementsByTagName('head')[0].",j,"(d.",h,"('script')).",k,"='",l,"//",a.l,"'",'"',"></",i,">"].join("")}var i="body",m=d[i];if (!m) {return setTimeout(ld,100)}a.P(1);var j="appendChild",h="createElement",k="src",n=d[h]("div"),v=n[j](d[h](z)),b=d[h]("iframe"),g="document",e="domain",o;n.style.display="none";m.insertBefore(n,m.firstChild).id=z;b.frameBorder="0";b.id=z+"-loader";if (/MSIE[ ]+6/.test(navigator.userAgent)) {b.src="javascript:false"}b.allowTransparency="true";v[j](b);try {b.contentWindow[g].open()}catch (w) {c[e]=d[e];o="javascript:var d="+g+".open();d.domain='"+d.domain+"';";b[k]=o+"void(0);"}try {var t=b.contentWindow[g];t.write(p());t.close()}catch (x) {b[k]=o+'d.write("'+p().replace(/"/g,String.fromCharCode(92)+'"')+'");d.close();'}a.P(2)};ld()};nt()})({ loader: "static.olark.com/jsclient/loader0.js", name:"olark", methods:["configure","extend","declare","identify"] });
+  window.olark.identify(this.options.siteId);
   callback();
 };
 
 /**
  * Page.
  *
- * @param {Page} page
+ * @param {Facade} page
  */
 
 Olark.prototype.page = function(page){
-  if (!this.options.page || !this._open) return;
+  if (!this.options.page) return;
   var props = page.properties();
   var name = page.fullName();
-
   if (!name && !props.url) return;
 
-  var msg = name ? name.toLowerCase() + ' page' : props.url;
-
-  chat('sendNotificationToOperator', {
-    body: 'looking at ' + msg // lowercase since olark does
-  });
+  name = name ? name + ' page' : props.url;
+  this.notify('looking at ' + name);
 };
 
 /**
  * Identify.
  *
- * @param {String} id (optional)
- * @param {Object} traits (optional)
- * @param {Object} options (optional)
+ * @param {Facade} identify
  */
 
 Olark.prototype.identify = function(identify){
@@ -108,66 +97,56 @@ Olark.prototype.identify = function(identify){
   var id = identify.userId();
   var email = identify.email();
   var phone = identify.phone();
-  var name = identify.name()
-    || identify.firstName();
+  var name = identify.name() || identify.firstName();
 
-  visitor('updateCustomFields', traits);
-  if (email) visitor('updateEmailAddress', { emailAddress: email });
-  if (phone) visitor('updatePhoneNumber', { phoneNumber: phone });
-
-  // figure out best name
-  if (name) visitor('updateFullName', { fullName: name });
+  if (traits) api('visitor.updateCustomFields', traits);
+  if (email) api('visitor.updateEmailAddress', { emailAddress: email });
+  if (phone) api('visitor.updatePhoneNumber', { phoneNumber: phone });
+  if (name) api('visitor.updateFullName', { fullName: name });
 
   // figure out best nickname
   var nickname = name || email || username || id;
   if (name && email) nickname += ' (' + email + ')';
-  if (nickname) chat('updateVisitorNickname', { snippet: nickname });
+  if (nickname) api('chat.updateVisitorNickname', { snippet: nickname });
 };
 
 /**
  * Track.
  *
- * @param {String} event
- * @param {Object} properties (optional)
- * @param {Object} options (optional)
+ * @param {Facade} track
  */
 
 Olark.prototype.track = function(track){
-  if (!this.options.track || !this._open) return;
-  chat('sendNotificationToOperator', {
-    body: 'visitor triggered "' + track.event() + '"' // lowercase since olark does
+  if (!this.options.track) return;
+  this.notify('visitor triggered "' + track.event() + '"');
+};
+
+/**
+ * Send a notification `message` to the operator, only when a chat is active and
+ * when the chat is open.
+ *
+ * @param {String} message
+ */
+
+Olark.prototype.notify = function(message){
+  if (!this._open) return;
+
+  // lowercase since olark does
+  message = message.toLowerCase();
+
+  api('visitor.getDetails', function(data){
+    if (!data || !data.isConversing) return;
+    api('chat.sendNotificationToOperator', { body: message });
   });
 };
 
 /**
- * Helper method for Olark box API calls.
+ * Helper for Olark API calls.
  *
  * @param {String} action
  * @param {Object} value
  */
 
-function box(action, value){
-  window.olark('api.box.' + action, value);
-}
-
-/**
- * Helper method for Olark visitor API calls.
- *
- * @param {String} action
- * @param {Object} value
- */
-
-function visitor(action, value){
-  window.olark('api.visitor.' + action, value);
-}
-
-/**
- * Helper method for Olark chat API calls.
- *
- * @param {String} action
- * @param {Object} value
- */
-
-function chat(action, value){
-  window.olark('api.chat.' + action, value);
+function api(action, value) {
+  window.olark('api.' + action, value);
 }

--- a/lib/olark/test.js
+++ b/lib/olark/test.js
@@ -7,6 +7,7 @@ var once = require('once');
 var when = require('when');
 var plugin = require('./');
 var sandbox = require('clear-env');
+var extend = require('extend');
 
 describe('Olark', function(){
   var Olark = plugin;
@@ -217,11 +218,12 @@ describe('Olark', function(){
 
     describe('not open', function(){
       beforeEach(function(){
-        analytics.stub(window, 'olark');
+        analytics.spy(window, 'olark');
       });
 
       describe('#page', function(){
         it('should not send an event when the chat isnt open', function(){
+          olark.options.page = true;
           analytics.page();
           analytics.didNotCall(window.olark);
         });
@@ -241,10 +243,10 @@ describe('Olark', function(){
       });
     });
 
-    describe('open', function(){
+    describe('open and not conversing', function(){
       beforeEach(function(done){
         expandThen(function(){
-          analytics.stub(window, 'olark');
+          analytics.spy(window, 'olark');
           done();
         });
       });
@@ -257,11 +259,50 @@ describe('Olark', function(){
       });
 
       describe('#page', function(){
-        // it('should not send a message without a name or url', function(){
-        //   analytics.page();
-        //   analytics.didNotCall(window.olark);
-        // });
+        it('should not send a notification', function(){
+          analytics.page();
+          analytics.didNotCall(window.olark, 'api.chat.sendNotificationToOperator');
+        });
 
+        it('should not send a notification when the chat isnt open', function(){
+          olark.options.page = true;
+          analytics.page();
+          analytics.didNotCall(window.olark, 'api.chat.sendNotificationToOperator');
+        });
+      });
+
+      describe('#track', function(){
+        it('should not send a notification by default', function(){
+          analytics.track('event');
+          analytics.didNotCall(window.olark, 'api.chat.sendNotificationToOperator');
+        });
+
+        it('should not send a notification when the chat isnt open', function(){
+          olark.options.track = true;
+          analytics.track('event');
+          analytics.didNotCall(window.olark, 'api.chat.sendNotificationToOperator');
+        });
+      });
+    });
+
+    describe('open and conversing', function(){
+      beforeEach(function(done){
+        // force the chat to start, so the user is considered "conversing"
+        window.olark('api.chat.sendMessageToVisitor', { body: 'conversing' });
+        expandThen(function(){
+          analytics.spy(window, 'olark');
+          done();
+        });
+      });
+
+      afterEach(function(done){
+        analytics.restore();
+        shrinkThen(function(){
+          done();
+        });
+      });
+
+      describe('#page', function(){
         it('should send a page name', function(){
           analytics.page('Name');
           analytics.called(window.olark, 'api.chat.sendNotificationToOperator', {
@@ -304,11 +345,13 @@ describe('Olark', function(){
 });
 
 function expandThen(fn) {
+  if (document.querySelector('.olrk-state-expanded')) return fn();
   window.olark('api.box.onExpand', once(fn));
   window.olark('api.box.expand');
 }
 
 function shrinkThen(fn) {
+  if (document.querySelector('.olrk-state-compressed')) return fn();
   window.olark('api.box.onShrink', once(fn));
   window.olark('api.box.shrink');
 }


### PR DESCRIPTION
Long story short:

We were checking if the box was open, but there was a slight edge-case where the user had decided to open the box, but hadn't explicitly started a conversation with the operator. If they did that and then trigger an event or page view while the box was open, you'd get a phantom chat appear on the operator's side. At least that's my best guess.

Now we're using the Olark API to check whether the user `isConversing` every time. We also keep the "opened" check too because Olark doesn't actually swap `isConversing` to false when they're done, so if we didn't we'd end up keeping the conversations going forever until the user stopped sending any events or pages.

Also edited the tests so that they are a bit more fullproof, and updated the spy.

cc @lancejpollard @calvinfo 
