### PR TITLE
Support `--only` and `--except` options for bin/integration

### DIFF
--- a/bin/integrations
+++ b/bin/integrations
@@ -13,6 +13,9 @@ var readdir = fs.readdirSync;
  * Get all of the slugs from the directory structure itself.
  */
 
+var availableSlugs = readdir(__dirname + '/../lib')
+  .filter(function(slug){ return fs.existsSync(path.join('./lib', slug, 'index.js')); });
+
 write(__dirname + '/../integrations.js', [
   "",
   "/**",
@@ -20,8 +23,7 @@ write(__dirname + '/../integrations.js', [
   " */",
   "",
   "module.exports = [",
-    readdir(__dirname + '/../lib')
-      .filter(function(slug){ return fs.existsSync(path.join('./lib', slug, 'index.js')); })
+    availableSlugs
       .map(function(slug){ return "require('./lib/" + slug + "')"; })
       .join(',\n')
       .replace(/^/gm, '  '),

--- a/bin/integrations
+++ b/bin/integrations
@@ -6,15 +6,50 @@
 
 var fs = require('fs');
 var path = require('path');
+var _ = require('lodash');
 var write = fs.writeFileSync;
 var readdir = fs.readdirSync;
 
 /**
- * Get all of the slugs from the directory structure itself.
+ * Parse options
  */
 
-var availableSlugs = readdir(__dirname + '/../lib')
+var args = process.argv;
+var onlyArg = "--only";
+var exceptArg = "--except";
+var listArg = "--list";
+
+var listing = false;
+var onlyArgStart = args.indexOf(onlyArg);
+var exceptArgStart = args.indexOf(exceptArg);
+
+if(args.indexOf(listArg) >= 0) {
+  args.slice(args.indexOf(listArg), 1);
+  listing = true;
+}
+
+var slugs = readdir(__dirname + '/../lib')
   .filter(function(slug){ return fs.existsSync(path.join('./lib', slug, 'index.js')); });
+
+if(onlyArgStart >= 0 && exceptArgStart >= 0) {
+  console.log("Both", onlyArg, "and", exceptArg, "arguments were given, but only one is allowed.");
+  process.exit(1);
+} else if(onlyArgStart >= 0) {
+  var args = args.slice(onlyArgStart + 1);
+  slugs = _.intersection(slugs, args);
+} else if(exceptArgStart >= 0) {
+  var args = args.slice(exceptArgStart + 1);
+  args.unshift(slugs);
+  slugs = _.without.apply(this, args);
+}
+
+if(listing) {
+  console.log(slugs.join("\n"));
+}
+
+/**
+ * Get all of the slugs from the directory structure itself.
+ */
 
 write(__dirname + '/../integrations.js', [
   "",
@@ -23,7 +58,7 @@ write(__dirname + '/../integrations.js', [
   " */",
   "",
   "module.exports = [",
-    availableSlugs
+    slugs
       .map(function(slug){ return "require('./lib/" + slug + "')"; })
       .join(',\n')
       .replace(/^/gm, '  '),

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "mocha-phantomjs": "~3.1.5",
     "phantomjs": "~1.9.2-2",
     "mocha": "~1.18.2",
-    "jscs": "^1.3.0"
+    "jscs": "^1.3.0",
+    "lodash": "~2.4.1"
   },
   "engines": {
     "node": ">= 0.11"


### PR DESCRIPTION
Adds command-line flags for `bin/integration`:
- `--only` will limit the integrations to those given
- `--except` will exclude any given integrations
- `--list` will output the list of integrations during the build

This is useful for producing custom builds.

Example usage:

```
bin/integration --only uservoice optimizely
bin/integration --except pingdom quantcast rollbar --list
```

Motivation is to produce custom builds of `analytics.js` that only contains enough to cover the services we use.

Build failure seems unrelated.
