### PR TITLE
Return cloned props for setGlobalProperties

### DIFF
--- a/lib/keen-io/index.js
+++ b/lib/keen-io/index.js
@@ -4,6 +4,7 @@
  */
 
 var integration = require('analytics.js-integration');
+var clone = require('clone');
 
 /**
  * Expose `Keen IO` integration.
@@ -150,7 +151,7 @@ Keen.prototype.identify = function(identify){
   };
 
   this.client.setGlobalProperties(function(){
-    return props;
+    return clone(props);
   });
 };
 


### PR DESCRIPTION
keen-js modifies the props object after its returned from the setGlobalProperties factory method:

https://github.com/keenlabs/keen-js/blob/master/src/track.js#L91

```
    // Add properties from client.globalProperties
    if (this.client.globalProperties) {
      newEvent = this.client.globalProperties(eventCollection);
    }

    // Add properties from user-defined event
    for (var property in payload) {
      if (payload.hasOwnProperty(property)) {
        newEvent[property] = payload[property];
      }
    }
```

Because `props` captured in the closure, we need to return a `cloned` version of it, so that the keen library wont continue to build up more properties on the props object with each track call.

@dustinlarimer @lancejpollard 
