### PR TITLE
insidevault: support multiple events

### DIFF
--- a/lib/insidevault/index.js
+++ b/lib/insidevault/index.js
@@ -6,6 +6,7 @@
 var integration = require('analytics.js-integration');
 var push = require('global-queue')('_iva');
 var Track = require('facade').Track;
+var each = require('each');
 var is = require('is');
 
 /**
@@ -70,16 +71,14 @@ InsideVault.prototype.page = function(page){
 
 InsideVault.prototype.track = function(track){
   var user = this.analytics.user();
-  var events = this.options.events;
-  var event = track.event();
+  var events = this.events(track.event());
   var value = track.revenue() || track.value() || 0;
   var eventId = track.orderId() || user.id() || '';
-  if (!has.call(events, event)) return;
-  event = events[event];
-
-  // 'sale' is a special event that will be routed to a table that is deprecated on InsideVault's end.
-  // They don't want a generic 'sale' event to go to their deprecated table.
-  if (event != 'sale') {
-    push('trackEvent', event, value, eventId);
-  }
+  each(events, function(event){
+    // 'sale' is a special event that will be routed to a table that is deprecated on InsideVault's end.
+    // They don't want a generic 'sale' event to go to their deprecated table.
+    if (event != 'sale') {
+      push('trackEvent', event, value, eventId);
+    }
+  });
 };

--- a/lib/insidevault/test.js
+++ b/lib/insidevault/test.js
@@ -141,6 +141,20 @@ describe('InsideVault', function(){
         analytics.called(window._iva.push, ['trackEvent', 'event1', 0, 'id']);
       });
 
+      it('should track multiple events', function(){
+        iv.options.events = [
+          { key: 'completed order', value: 'event1' },
+          { key: 'completed order', value: 'event2' }
+        ];
+
+        window._iva = [];
+        analytics.track('completed order', { orderId: 'id', revenue: 9.99 });
+        analytics.assert.deepEqual(window._iva, [
+          ['trackEvent', 'event1', 9.99, 'id'],
+          ['trackEvent', 'event2', 9.99, 'id']
+        ]);
+      });
+
       it('should not track a "sale" event', function(){
         analytics.track('sale');
         analytics.didNotCall(window._iva.push);


### PR DESCRIPTION
not a huge deal, but we are going to move from `{ key: value }`, to `[{ key: 'key', value: 'value' }]`, so that people can map multiple pixels to a single event.
going to add this server side too.

cc @lancejpollard 
