### PR TITLE
bugsnag: use amd when possible

### DIFF
--- a/lib/bugsnag/index.js
+++ b/lib/bugsnag/index.js
@@ -9,13 +9,25 @@ var extend = require('extend');
 var onError = require('on-error');
 
 /**
+ * UMD ?
+ */
+
+var umd = 'function' == typeof define && define.amd;
+
+/**
+ * Source.
+ */
+
+var src = '//d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.min.js';
+
+/**
  * Expose `Bugsnag` integration.
  */
 
 var Bugsnag = module.exports = integration('Bugsnag')
   .global('Bugsnag')
   .option('apiKey', '')
-  .tag('<script src="//d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.min.js">');
+  .tag('<script src="' + src + '">');
 
 /**
  * Initialize.
@@ -27,6 +39,16 @@ var Bugsnag = module.exports = integration('Bugsnag')
 
 Bugsnag.prototype.initialize = function(page){
   var self = this;
+
+  if (umd) {
+    window.require([src], function(bugsnag){
+      bugsnag.apiKey = self.options.apiKey;
+      window.Bugsnag = bugsnag;
+      self.ready();
+    });
+    return;
+  }
+
   this.load(function(){
     window.Bugsnag.apiKey = self.options.apiKey;
     self.ready();

--- a/test/index.html
+++ b/test/index.html
@@ -4,7 +4,7 @@
   <title>integrations tests</title>
   <link rel="stylesheet" href="/test/mocha.css">
   <!-- amd -->
-
+  <script src="//requirejs.org/docs/release/2.1.15/minified/require.js"></script>
   <!-- Synchronous Integrations -->
   <script src="//cdn.optimizely.com/js/170430035.js"></script>
   <script type='text/javascript'>


### PR DESCRIPTION
when requirejs / amd is loaded bugsnag, will not set `window.Bugsnag` so it will not work on apps that use amd.
this fixes the issue, i ran the tests with and without requirejs and it works.

closes #387 

cc @lancejpollard 
