### PR TITLE
GA: added non-interaction parameter based on options

### DIFF
--- a/lib/google-analytics/index.js
+++ b/lib/google-analytics/index.js
@@ -48,6 +48,7 @@ var GA = exports.Integration = integration('Google Analytics')
   .option('domain', 'auto')
   .option('doubleClick', false)
   .option('enhancedLinkAttribution', false)
+  .option('nonInteraction', 0)
   .option('ignoredReferrers', null)
   .option('includeSearch', false)
   .option('siteSpeedSampleRate', 1)
@@ -159,13 +160,13 @@ GA.prototype.page = function(page){
   // categorized pages
   if (category && this.options.trackCategorizedPages) {
     track = page.track(category);
-    this.track(track, { noninteraction: true });
+    this.track(track, { nonInteraction: 1 });
   }
 
   // named pages
   if (name && this.options.trackNamedPages) {
     track = page.track(name);
-    this.track(track, { noninteraction: true });
+    this.track(track, { nonInteraction: 1 });
   }
 };
 
@@ -186,7 +187,7 @@ GA.prototype.track = function(track, options){
     eventCategory: props.category || this._category || 'All',
     eventLabel: props.label,
     eventValue: formatValue(props.value || track.revenue()),
-    nonInteraction: props.noninteraction || opts.noninteraction
+    nonInteraction: props.nonInteraction || opts.nonInteraction
   });
 };
 
@@ -317,13 +318,13 @@ GA.prototype.pageClassic = function(page){
   // categorized pages
   if (category && this.options.trackCategorizedPages) {
     track = page.track(category);
-    this.track(track, { noninteraction: true });
+    this.track(track, { nonInteraction: 1 });
   }
 
   // named pages
   if (name && this.options.trackNamedPages) {
     track = page.track(name);
-    this.track(track, { noninteraction: true });
+    this.track(track, { nonInteraction: 1 });
   }
 };
 
@@ -343,8 +344,8 @@ GA.prototype.trackClassic = function(track, options){
   var category = this._category || props.category || 'All';
   var label = props.label;
   var value = formatValue(revenue || props.value);
-  var noninteraction = props.noninteraction || opts.noninteraction;
-  push('_trackEvent', category, event, label, value, noninteraction);
+  var nonInteraction = props.nonInteraction || opts.nonInteraction;
+  push('_trackEvent', category, event, label, value, nonInteraction);
 };
 
 /**

--- a/lib/google-analytics/index.js
+++ b/lib/google-analytics/index.js
@@ -48,7 +48,7 @@ var GA = exports.Integration = integration('Google Analytics')
   .option('domain', 'auto')
   .option('doubleClick', false)
   .option('enhancedLinkAttribution', false)
-  .option('nonInteraction', 0)
+  .option('nonInteraction', false)
   .option('ignoredReferrers', null)
   .option('includeSearch', false)
   .option('siteSpeedSampleRate', 1)
@@ -187,7 +187,7 @@ GA.prototype.track = function(track, options){
     eventCategory: props.category || this._category || 'All',
     eventLabel: props.label,
     eventValue: formatValue(props.value || track.revenue()),
-    nonInteraction: props.nonInteraction || opts.nonInteraction
+    nonInteraction: !!(props.nonInteraction || opts.nonInteraction)
   });
 };
 
@@ -344,7 +344,7 @@ GA.prototype.trackClassic = function(track, options){
   var category = this._category || props.category || 'All';
   var label = props.label;
   var value = formatValue(revenue || props.value);
-  var nonInteraction = props.nonInteraction || opts.nonInteraction;
+  var nonInteraction = !!(props.nonInteraction || opts.nonInteraction);
   push('_trackEvent', category, event, label, value, nonInteraction);
 };
 

--- a/lib/google-analytics/test.js
+++ b/lib/google-analytics/test.js
@@ -33,6 +33,7 @@ describe('Google Analytics', function(){
       .option('domain', 'auto')
       .option('doubleClick', false)
       .option('enhancedLinkAttribution', false)
+      .option('nonInteraction',0)
       .option('ignoredReferrers', null)
       .option('siteSpeedSampleRate', 1)
       .option('trackingId', '')
@@ -238,7 +239,7 @@ describe('Google Analytics', function(){
             eventAction: 'Viewed Name Page',
             eventLabel: undefined,
             eventValue: 0,
-            nonInteraction: true
+            nonInteraction: 1
           });
         });
 
@@ -249,7 +250,7 @@ describe('Google Analytics', function(){
             eventAction: 'Viewed Category Name Page',
             eventLabel: undefined,
             eventValue: 0,
-            nonInteraction: true
+            nonInteraction: 1
           });
         });
 
@@ -260,7 +261,7 @@ describe('Google Analytics', function(){
             eventAction: 'Viewed Category Page',
             eventLabel: undefined,
             eventValue: 0,
-            nonInteraction: true
+            nonInteraction: 1
           });
         });
 
@@ -358,24 +359,24 @@ describe('Google Analytics', function(){
         });
 
         it('should send a non-interaction property', function(){
-          analytics.track('event', { noninteraction: true });
+          analytics.track('event', { nonInteraction: 1 });
           analytics.called(window.ga, 'send', 'event', {
             eventCategory: 'All',
             eventAction: 'event',
             eventLabel: undefined,
             eventValue: 0,
-            nonInteraction: true
+            nonInteraction: 1
           });
         });
 
         it('should send a non-interaction option', function(){
-          analytics.track('event', {}, { 'Google Analytics': { noninteraction: true } });
+          analytics.track('event', {}, { 'Google Analytics': { nonInteraction: 1 } });
           analytics.called(window.ga, 'send', 'event', {
             eventCategory: 'All',
             eventAction: 'event',
             eventLabel: undefined,
             eventValue: 0,
-            nonInteraction: true
+            nonInteraction: 1
           });
         });
       });
@@ -611,17 +612,17 @@ describe('Google Analytics', function(){
 
         it('should track a named page', function(){
           analytics.page('Name');
-          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'Viewed Name Page', undefined, 0, true]);
+          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'Viewed Name Page', undefined, 0, 1]);
         });
 
         it('should track a named page with a category', function(){
           analytics.page('Category', 'Name');
-          analytics.called(window._gaq.push, ['_trackEvent', 'Category', 'Viewed Category Name Page', undefined, 0, true]);
+          analytics.called(window._gaq.push, ['_trackEvent', 'Category', 'Viewed Category Name Page', undefined, 0, 1]);
         });
 
         it('should track a categorized page', function(){
           analytics.page('Category', 'Name');
-          analytics.called(window._gaq.push, ['_trackEvent', 'Category', 'Viewed Category Page', undefined, 0, true]);
+          analytics.called(window._gaq.push, ['_trackEvent', 'Category', 'Viewed Category Page', undefined, 0, 1]);
         });
 
         it('should not track a named or categorized page when the option is off', function(){
@@ -670,14 +671,15 @@ describe('Google Analytics', function(){
         });
 
         it('should send a non-interaction property', function(){
-          analytics.track('event', { noninteraction: true });
-          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', undefined, 0, true]);
+          analytics.track('event', { nonInteraction: 1 });
+          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', undefined, 0, 1]);
         });
 
         it('should send a non-interaction option', function(){
-          analytics.track('event', {}, { 'Google Analytics': { noninteraction: true } });
-          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', undefined, 0, true]);
+          analytics.track('event', {}, { 'Google Analytics': { nonInteraction: 1 } });
+          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', undefined, 0, 1]);
         });
+
       });
 
       describe('ecommerce', function(){

--- a/lib/google-analytics/test.js
+++ b/lib/google-analytics/test.js
@@ -33,7 +33,7 @@ describe('Google Analytics', function(){
       .option('domain', 'auto')
       .option('doubleClick', false)
       .option('enhancedLinkAttribution', false)
-      .option('nonInteraction',0)
+      .option('nonInteraction',false)
       .option('ignoredReferrers', null)
       .option('siteSpeedSampleRate', 1)
       .option('trackingId', '')
@@ -239,7 +239,7 @@ describe('Google Analytics', function(){
             eventAction: 'Viewed Name Page',
             eventLabel: undefined,
             eventValue: 0,
-            nonInteraction: 1
+            nonInteraction: true
           });
         });
 
@@ -250,7 +250,7 @@ describe('Google Analytics', function(){
             eventAction: 'Viewed Category Name Page',
             eventLabel: undefined,
             eventValue: 0,
-            nonInteraction: 1
+            nonInteraction: true
           });
         });
 
@@ -261,7 +261,7 @@ describe('Google Analytics', function(){
             eventAction: 'Viewed Category Page',
             eventLabel: undefined,
             eventValue: 0,
-            nonInteraction: 1
+            nonInteraction: true
           });
         });
 
@@ -286,7 +286,7 @@ describe('Google Analytics', function(){
             eventAction: 'event',
             eventLabel: undefined,
             eventValue: 0,
-            nonInteraction: undefined
+            nonInteraction: false
           });
         });
 
@@ -297,7 +297,7 @@ describe('Google Analytics', function(){
             eventAction: 'event',
             eventLabel: undefined,
             eventValue: 0,
-            nonInteraction: undefined
+            nonInteraction: false
           });
         });
 
@@ -309,7 +309,7 @@ describe('Google Analytics', function(){
             eventAction: 'event',
             eventLabel: undefined,
             eventValue: 0,
-            nonInteraction: undefined
+            nonInteraction: false
           });
         });
 
@@ -321,7 +321,7 @@ describe('Google Analytics', function(){
             eventAction: 'event',
             eventLabel: undefined,
             eventValue: 0,
-            nonInteraction: undefined
+            nonInteraction: false
           });
         });
 
@@ -332,7 +332,7 @@ describe('Google Analytics', function(){
             eventAction: 'event',
             eventLabel: 'label',
             eventValue: 0,
-            nonInteraction: undefined
+            nonInteraction: false
           });
         });
 
@@ -343,7 +343,7 @@ describe('Google Analytics', function(){
             eventAction: 'event',
             eventLabel: undefined,
             eventValue: 1,
-            nonInteraction: undefined
+            nonInteraction: false
           });
         });
 
@@ -354,7 +354,7 @@ describe('Google Analytics', function(){
             eventAction: 'event',
             eventLabel: undefined,
             eventValue: 10,
-            nonInteraction: undefined
+            nonInteraction: false
           });
         });
 
@@ -365,7 +365,7 @@ describe('Google Analytics', function(){
             eventAction: 'event',
             eventLabel: undefined,
             eventValue: 0,
-            nonInteraction: 1
+            nonInteraction: true
           });
         });
 
@@ -376,7 +376,7 @@ describe('Google Analytics', function(){
             eventAction: 'event',
             eventLabel: undefined,
             eventValue: 0,
-            nonInteraction: 1
+            nonInteraction: true
           });
         });
       });
@@ -612,17 +612,17 @@ describe('Google Analytics', function(){
 
         it('should track a named page', function(){
           analytics.page('Name');
-          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'Viewed Name Page', undefined, 0, 1]);
+          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'Viewed Name Page', undefined, 0, true]);
         });
 
         it('should track a named page with a category', function(){
           analytics.page('Category', 'Name');
-          analytics.called(window._gaq.push, ['_trackEvent', 'Category', 'Viewed Category Name Page', undefined, 0, 1]);
+          analytics.called(window._gaq.push, ['_trackEvent', 'Category', 'Viewed Category Name Page', undefined, 0, true]);
         });
 
         it('should track a categorized page', function(){
           analytics.page('Category', 'Name');
-          analytics.called(window._gaq.push, ['_trackEvent', 'Category', 'Viewed Category Page', undefined, 0, 1]);
+          analytics.called(window._gaq.push, ['_trackEvent', 'Category', 'Viewed Category Page', undefined, 0, true]);
         });
 
         it('should not track a named or categorized page when the option is off', function(){
@@ -641,43 +641,43 @@ describe('Google Analytics', function(){
 
         it('should send an event', function(){
           analytics.track('event');
-          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', undefined, 0, undefined]);
+          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', undefined, 0, false]);
         });
 
         it('should send a category property', function(){
           analytics.track('event', { category: 'category' });
-          analytics.called(window._gaq.push, ['_trackEvent', 'category', 'event', undefined, 0, undefined]);
+          analytics.called(window._gaq.push, ['_trackEvent', 'category', 'event', undefined, 0, false]);
         });
 
         it('should send a stored category', function(){
           analytics.page('category');
           analytics.track('event', { category: 'category' });
-          analytics.called(window._gaq.push, ['_trackEvent', 'category', 'event', undefined, 0, undefined]);
+          analytics.called(window._gaq.push, ['_trackEvent', 'category', 'event', undefined, 0, false]);
         });
 
         it('should send a label property', function(){
           analytics.track('event', { label: 'label' });
-          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', 'label', 0, undefined]);
+          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', 'label', 0, false]);
         });
 
         it('should send a rounded value property', function(){
           analytics.track('event', { value: 1.1 });
-          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', undefined, 1, undefined]);
+          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', undefined, 1, false]);
         });
 
         it('should prefer a rounded revenue property', function(){
           analytics.track('event', { revenue: 9.99 });
-          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', undefined, 10, undefined]);
+          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', undefined, 10, false]);
         });
 
         it('should send a non-interaction property', function(){
           analytics.track('event', { nonInteraction: 1 });
-          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', undefined, 0, 1]);
+          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', undefined, 0, true]);
         });
 
         it('should send a non-interaction option', function(){
           analytics.track('event', {}, { 'Google Analytics': { nonInteraction: 1 } });
-          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', undefined, 0, 1]);
+          analytics.called(window._gaq.push, ['_trackEvent', 'All', 'event', undefined, 0, true]);
         });
 
       });


### PR DESCRIPTION
@harrietgrace @calvinfo 

We're adding an advanced option in the GA integration to allow our customers to choose whether to mark all track events as non-interactive or not. Events are by default 'interactive', meaning they count as an interaction with the website, and do no count towards bounce rate (people who view your website, and then leave without interacting / everyone who visits your page). Our customers will still have the ability to override this setting with individual event calls, if they wish to.

Fixes https://segment.zendesk.com/agent/#/tickets/17523
