### PR TITLE
add support for SPAs in comscore

### DIFF
--- a/lib/comscore/index.js
+++ b/lib/comscore/index.js
@@ -40,3 +40,13 @@ Comscore.prototype.initialize = function(page){
 Comscore.prototype.loaded = function(){
   return !! window.COMSCORE;
 };
+
+/**
+ * Page
+ *
+ * @return {Boolean}
+ */
+
+Comscore.prototype.page = function(page){
+  window.COMSCORE.beacon(this.options);
+};

--- a/lib/comscore/index.js
+++ b/lib/comscore/index.js
@@ -44,7 +44,7 @@ Comscore.prototype.loaded = function(){
 /**
  * Page
  *
- * @return {Boolean}
+ * @param {Object} page
  */
 
 Comscore.prototype.page = function(page){

--- a/lib/comscore/test.js
+++ b/lib/comscore/test.js
@@ -56,4 +56,24 @@ describe('comScore', function(){
       analytics.load(comscore, done);
     });
   });
+
+  describe('after loading', function(){
+    beforeEach(function(done){
+      analytics.once('ready', done);
+      analytics.initialize();
+      analytics.page();
+    });
+
+    describe('#page', function(){
+      beforeEach(function(){
+        analytics.stub(window.COMSCORE, 'beacon');
+      });
+
+      it('should call only on 2nd page', function(){
+        analytics.didNotCall(window.COMSCORE.beacon, {'c1':'2', 'c2':'x'});
+        analytics.page();
+        analytics.called(window.COMSCORE.beacon, {'c1':'2', 'c2':'x'});
+      });
+    });
+  });
 });


### PR DESCRIPTION
https://segment.zendesk.com/agent/#/tickets/17921

adds support for SPAs in comscore. 

we should have a direct comscore contact via the support request soon, but in the meantime 20 second screenshare to prove this works: https://cloudup.com/iHwDIodsQsh
