### PR TITLE
Update GoSquared w/ `identify` method

### DIFF
--- a/lib/gosquared/index.js
+++ b/lib/gosquared/index.js
@@ -69,7 +69,7 @@ GoSquared.prototype.loaded = function(){
 /**
  * Page.
  *
- * https://www.gosquared.com/developer/tracker/pageviews
+ * https://beta.gosquared.com/docs/tracking/api/#pageviews
  *
  * @param {Page} page
  */
@@ -83,26 +83,36 @@ GoSquared.prototype.page = function(page){
 /**
  * Identify.
  *
- * https://www.gosquared.com/developer/tracker/tagging
+ * https://beta.gosquared.com/docs/tracking/identify
  *
  * @param {Identify} identify
  */
 
 GoSquared.prototype.identify = function(identify){
-  var traits = identify.traits({ userId: 'userID' });
-  var username = identify.username();
-  var email = identify.email();
+  var traits = identify.traits({
+    userId: 'user_id',
+    created: 'created_at'
+  });
+
   var id = identify.userId();
-  if (id) push('set', 'visitorID', id);
-  var name =  email || username || id;
+  var name = identify.name();
+  var email = identify.email();
+  var username = identify.username();
+
+  if (id) {
+    push('identify', id, traits);
+  } else {
+    push('properties', traits);
+  }
+
+  var name = email || username || id;
   if (name) push('set', 'visitorName', name);
-  push('set', 'visitor', traits);
 };
 
 /**
  * Track.
  *
- * https://www.gosquared.com/developer/tracker/events
+ * https://beta.gosquared.com/docs/tracking/events
  *
  * @param {Track} track
  */
@@ -113,6 +123,8 @@ GoSquared.prototype.track = function(track){
 
 /**
  * Checked out.
+ *
+ * https://beta.gosquared.com/docs/tracking/ecommerce
  *
  * @param {Track} track
  * @api private

--- a/lib/gosquared/test.js
+++ b/lib/gosquared/test.js
@@ -122,22 +122,21 @@ describe('GoSquared', function(){
 
       it('should set an id', function(){
         analytics.identify('id');
-        analytics.called(window._gs, 'set', 'visitorID', 'id');
+        analytics.called(window._gs, 'identify', 'id');
       });
 
       it('should set traits', function(){
         analytics.identify({ trait: true });
-        analytics.called(window._gs, 'set', 'visitor', { trait: true });
+        analytics.called(window._gs, 'properties', { trait: true });
       });
 
       it('should set an id and traits', function(){
         analytics.identify('id', { trait: true });
-        analytics.called(window._gs, 'set', 'visitorID', 'id')
-        analytics.called(window._gs, 'set', 'visitor', {
-          userID: 'id',
+        analytics.called(window._gs, 'identify', 'id', {
           trait: true,
-          id: 'id'
-        });
+          id: 'id',
+          user_id: 'id'
+        })
       });
 
       it('should prefer an email for visitor name', function(){


### PR DESCRIPTION
The GoSquared tracker now has nicer `identify` and `properties` functions to replace the visitorID and visitor setting. I believe it's all backwards and forwards compatible.

Note: any idea why https://github.com/segmentio/analytics.js-integrations/blob/master/lib/gosquared/index.js#L51-L54 is in there? It doesn't seem to be in any other integrations
