### PR TITLE
add customerio page support

### DIFF
--- a/lib/customerio/index.js
+++ b/lib/customerio/index.js
@@ -5,6 +5,7 @@
 
 var alias = require('alias');
 var convertDates = require('convert-dates');
+var extend = require('extend');
 var Identify = require('facade').Identify;
 var integration = require('analytics.js-integration');
 
@@ -41,6 +42,29 @@ Customerio.prototype.initialize = function(page){
 Customerio.prototype.loaded = function(){
   return (!! window._cio) && (window._cio.push !== Array.prototype.push);
 };
+
+
+
+/**
+ * Page.
+ *
+ * @param {Page} page
+ */
+
+Customerio.prototype.page = function(page){
+  var referrer = page.referrer();
+  var url = page.url();
+  var props = {
+    width: window.innerWidth,
+    height: window.innerHeight
+  };
+
+  if (referrer) extend(props, {referrer: referrer});
+
+  window._cio.page(url, props);
+};
+
+
 
 /**
  * Identify.

--- a/lib/customerio/test.js
+++ b/lib/customerio/test.js
@@ -69,6 +69,20 @@ describe('Customer.io', function(){
       analytics.page();
     });
 
+    describe('#page', function(){
+      beforeEach(function(){
+        analytics.stub(window._cio, 'page');
+      });
+
+      it('should send a page call', function(){
+        var url = document.location.href;
+        var width = window.innerWidth;
+        var height = window.innerHeight;
+        analytics.page();
+        analytics.called(window._cio.page, url, {width: width, height: height});
+      });
+    });
+
     describe('#identify', function(){
       beforeEach(function(){
         analytics.stub(window._cio, 'identify');


### PR DESCRIPTION
customer.io's js lib calls `.page` on load, but they also have an method by which we can report a virtual pageview on the client side. 

It takes the url and then an object containing window width, height, and the referrer. Here's the email from their team explaining: https://segment.zendesk.com/agent/tickets/18002

And here's an example of it being called in their lib: https://cloudup.com/cKAB8hbsVoT
