### PR TITLE
adds GA support for explicitly passed campaign info

### DIFF
--- a/lib/google-analytics/index.js
+++ b/lib/google-analytics/index.js
@@ -112,7 +112,7 @@ GA.prototype.initialize = function(){
   };
   window.ga.l = new Date().getTime();
 
-  if(window.location.hostname == 'localhost') opts.domain = 'none';
+  if (window.location.hostname == 'localhost') opts.domain = 'none';
 
   window.ga('create', opts.trackingId, {
     cookieDomain: opts.domain || GA.prototype.defaults.domain, // to protect against empty string
@@ -163,17 +163,24 @@ GA.prototype.page = function(page){
   var category = page.category();
   var props = page.properties();
   var name = page.fullName();
+  var campaign = page.proxy('context.campaign') || {};
   var pageview = {};
   var track;
 
   this._category = category; // store for later
 
+  pageview.page = path(props, this.options);
+  pageview.title = name || props.title;
+  pageview.location = props.url;
+
+  if (campaign.name) pageview.campaignName = '(' + campaign.name + ')';
+  if (campaign.source) pageview.campaignSource = '(' + campaign.source + ')';
+  if (campaign.medium) pageview.campaignMedium = campaign.medium;
+  if (campaign.content) pageview.campaignContent = campaign.content;
+  if (campaign.term) pageview.campaignKeyword = campaign.term;
+
   // send
-  window.ga('send', 'pageview', {
-    page: path(props, this.options),
-    title: name || props.title,
-    location: props.url
-  });
+  window.ga('send', 'pageview', pageview);
 
   // categorized pages
   if (category && this.options.trackCategorizedPages) {
@@ -199,18 +206,27 @@ GA.prototype.page = function(page){
 
 GA.prototype.track = function(track, options){
   var contextOpts = track.options(this.name);
-  var interfaceOpts = this.options;    
+  var interfaceOpts = this.options;
   var opts = defaults(options || {}, contextOpts);
   opts = defaults(opts, interfaceOpts);
   var props = track.properties();
-  
-  window.ga('send', 'event', {
+  var campaign = track.proxy('context.campaign') || {};
+
+  var payload = {
     eventAction: track.event(),
     eventCategory: props.category || this._category || 'All',
     eventLabel: props.label,
     eventValue: formatValue(props.value || track.revenue()),
     nonInteraction: !!(props.nonInteraction || opts.nonInteraction)
-  });
+  };
+
+  if (campaign.name) payload.campaignName = '(' + campaign.name + ')';
+  if (campaign.source) payload.campaignSource = '(' + campaign.source + ')';
+  if (campaign.medium) payload.campaignMedium = campaign.medium;
+  if (campaign.content) payload.campaignContent = campaign.content;
+  if (campaign.term) payload.campaignKeyword = campaign.term;
+
+  window.ga('send', 'event', payload);
 };
 
 /**

--- a/lib/google-analytics/test.js
+++ b/lib/google-analytics/test.js
@@ -210,7 +210,7 @@ describe('Google Analytics', function(){
           analytics.called(window.ga, 'send', 'pageview', {
             page: window.location.pathname,
             title: document.title,
-            location: window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port: '') + window.location.pathname + window.location.search
+            location: window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '') + window.location.pathname + window.location.search
           });
         });
 
@@ -233,6 +233,29 @@ describe('Google Analytics', function(){
           });
         });
 
+        it('should send the campaign info if its included', function(){
+          ga.options.includeSearch = true;
+          analytics.page('category', 'name', { url: 'url', path: '/path', search: '?q=1' }, {
+            campaign: {
+              name: "test",
+              source: "test",
+              medium: "test",
+              term: "test",
+              content : "test"
+            }
+          });
+          analytics.called(window.ga, 'send', 'pageview', {
+            page: '/path?q=1',
+            title: 'category name',
+            location: 'url',
+            campaignName: '(test)',
+            campaignSource: '(test)',
+            campaignMedium: "test",
+            campaignKeyword: "test",
+            campaignContent: "test"
+          });
+        });
+
         it('should track a named page', function(){
           analytics.page('Name');
           analytics.called(window.ga, 'send', 'event', {
@@ -241,6 +264,30 @@ describe('Google Analytics', function(){
             eventLabel: undefined,
             eventValue: 0,
             nonInteraction: true
+          });
+        });
+
+        it('should track a named page with context', function(){
+          analytics.page('Name', {}, {
+            campaign: {
+              name: "test",
+              source: "test",
+              medium: "test",
+              term: "test",
+              content : "test"
+            }
+          });
+          analytics.called(window.ga, 'send', 'event', {
+            eventCategory: 'All',
+            eventAction: 'Viewed Name Page',
+            eventLabel: undefined,
+            eventValue: 0,
+            nonInteraction: true,
+            campaignName: '(test)',
+            campaignSource: '(test)',
+            campaignMedium: "test",
+            campaignKeyword: "test",
+            campaignContent: "test"
           });
         });
 
@@ -288,6 +335,30 @@ describe('Google Analytics', function(){
             eventLabel: undefined,
             eventValue: 0,
             nonInteraction: false
+          });
+        });
+
+        it('should send an event with context', function(){
+          analytics.track('event', {}, {
+            campaign: {
+              name: "test",
+              source: "test",
+              medium: "test",
+              term: "test",
+              content : "test"
+            }
+          });
+          analytics.called(window.ga, 'send', 'event', {
+            eventCategory: 'All',
+            eventAction: 'event',
+            eventLabel: undefined,
+            eventValue: 0,
+            nonInteraction: false,
+            campaignName: '(test)',
+            campaignSource: '(test)',
+            campaignMedium: "test",
+            campaignKeyword: "test",
+            campaignContent: "test"
           });
         });
 


### PR DESCRIPTION
Ember apparently strips query string params (?), so normal/automatic UTM parsing is not an option for those users. Two recent tickets in zendesk about this. So we want to also respect campaign parameters passed explicitly in the context object. 

google field reference: https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#campaignName

example of the direct call this implementation is modeled after working as expected:

![](https://cldup.com/A4H7_Kii62.png)

leads to: 

![](https://cldup.com/Gt2cfnuSwp.png)

and all subsequent pageviews/events _in the session_ are also attributed to that campaign, because of the processing flow in this chart: https://developers.google.com/analytics/devguides/platform/campaign-flow

@DirtyAnalytics @calvinfo @amillet89 @yields 
