### PR TITLE
Amplitude: added setDomain and setGlobalUserProperties to init

### DIFF
--- a/lib/amplitude/index.js
+++ b/lib/amplitude/index.js
@@ -4,6 +4,8 @@
  */
 
 var integration = require('analytics.js-integration');
+var utm = require('utm-params');
+var top = require('top-domain');
 
 /**
  * Expose `Amplitude` integration.
@@ -27,7 +29,10 @@ var Amplitude = module.exports = integration('Amplitude')
 
 Amplitude.prototype.initialize = function(page){
   (function(h,a){var f=h.amplitude||{};f._q=[];function e(i){f[i]=function(){f._q.push([i].concat(Array.prototype.slice.call(arguments,0)))}}var c=["init","logEvent","setUserId","setUserProperties","setVersionName","setDomain","setGlobalUserProperties"];for(var d=0;d<c.length;d++){e(c[d])}h.amplitude=f})(window,document);
+
+  this.setDomain(window.location.href);
   window.amplitude.init(this.options.apiKey);
+  this.setGlobalUserProperties(window.location.search);
   this.load(this.ready);
 };
 
@@ -92,4 +97,26 @@ Amplitude.prototype.track = function(track){
   var props = track.properties();
   var event = track.event();
   window.amplitude.logEvent(event, props);
+};
+
+/**
+ * Set domain name to root domain
+ *
+ * @param {String} href
+ */
+
+Amplitude.prototype.setDomain = function(href){
+  var domain = top(href);
+  window.amplitude.setDomain(domain);
+};
+
+/**
+ * Set campaign params as global user properties
+ *
+ * @param {String} query
+ */
+
+Amplitude.prototype.setGlobalUserProperties = function(query){
+  var campaign = utm(query);
+  if (campaign) window.amplitude.setGlobalUserProperties(campaign);
 };

--- a/lib/amplitude/test.js
+++ b/lib/amplitude/test.js
@@ -58,6 +58,46 @@ describe('Amplitude', function(){
         analytics.page();
         analytics.called(amplitude.load);
       });
+
+      it('should set domain', function(){
+        analytics.spy(amplitude, 'setDomain');
+        analytics.initialize();
+        analytics.page();
+        analytics.called(amplitude.setDomain, window.location.href);
+      });
+
+      describe('#setDomain', function(){
+        beforeEach(function(){
+          analytics.initialize();
+        });
+
+        it('should call window.amplitude.setDomain with the top domain', function(){
+          var href = 'https://sub.domain.com/path';
+          analytics.spy(window.amplitude, 'setDomain');
+          amplitude.setDomain(href);
+          analytics.called(window.amplitude.setDomain, 'domain.com')
+        });
+      });
+
+      it('should set global user properties', function(){
+        analytics.spy(amplitude, 'setGlobalUserProperties');
+        analytics.initialize();
+        analytics.page();
+        analytics.called(amplitude.setGlobalUserProperties, window.location.search);
+      });
+
+      describe('#setGlobalUserProperties', function(){
+        beforeEach(function(){
+          analytics.initialize();
+        });
+
+        it('should set campaign object as global user property', function(){
+          var query = '?utm_source=source&utm_medium=medium&utm_term=term&utm_content=content&utm_campaign=name';
+          analytics.spy(window.amplitude, 'setGlobalUserProperties');
+          amplitude.setGlobalUserProperties(query);
+          analytics.called(window.amplitude.setGlobalUserProperties, {source:'source', medium:'medium', term:'term', content:'content', name:'name'});
+        });
+      });
     });
   });
 


### PR DESCRIPTION
fixes https://github.com/segmentio/analytics.js-integrations/pull/448

@DirtyAnalytics split the setDomain and setGlobalUserProperties into separate methods to be able to test them. For each of these we have two tests, one that checks that setDomain (setGlobalUserProperties) was called, and another that checks that the setDomain method calls the window.amplitude.setDomain with the right params

@yields : @calvinfo and I wondered if there's a better way to test these two methods if we kept them inside initialize? 
