### PR TITLE
Support running totals using Mixpanels increment

### DIFF
--- a/lib/mixpanel/index.js
+++ b/lib/mixpanel/index.js
@@ -170,7 +170,8 @@ Mixpanel.prototype.track = function(track){
 
   // increment properties in mixpanel people
   if (people && ~indexof(increments, increment)) {
-    window.mixpanel.people.increment(track.event());
+    var incrementBy = props['increment'] ? props['increment'] : 1;
+    window.mixpanel.people.increment(track.event(), incrementBy);
     window.mixpanel.people.set('Last ' + track.event(), new Date);
   }
 

--- a/lib/mixpanel/test.js
+++ b/lib/mixpanel/test.js
@@ -280,7 +280,14 @@ describe('Mixpanel', function(){
         mixpanel.options.increments = [0, 'my event', 1];
         mixpanel.options.people = true;
         analytics.track('my event');
-        analytics.called(window.mixpanel.people.increment, 'my event');
+        analytics.called(window.mixpanel.people.increment, 'my event', 1);
+      });
+	  
+      it('should increment events that are in .increments option with increment', function(){
+        mixpanel.options.increments = [0, 'my event', 1];
+        mixpanel.options.people = true;
+        analytics.track('my event', {increment: 5});
+        analytics.called(window.mixpanel.people.increment, 'my event', 5);
       });
 
       it('should should update people property if the event is in .increments', function(){


### PR DESCRIPTION
Mixpanel's documentation on the increment call states that:

> For each key and value in the properties argument, adds that amount to the associated property in the People Analytics profile with the given distinct id.

For example, say I have a property called "Credits used" and its value is 5. If I make another increment with a value of 2 the resulting value of "Credits Used" should be 7.

This change allows increment totals to be made if the events properties contain a value.
