### PR TITLE
remove parens from campaign params

### DIFF
--- a/lib/google-analytics/index.js
+++ b/lib/google-analytics/index.js
@@ -173,8 +173,8 @@ GA.prototype.page = function(page){
   pageview.title = name || props.title;
   pageview.location = props.url;
 
-  if (campaign.name) pageview.campaignName = '(' + campaign.name + ')';
-  if (campaign.source) pageview.campaignSource = '(' + campaign.source + ')';
+  if (campaign.name) pageview.campaignName = campaign.name;
+  if (campaign.source) pageview.campaignSource = campaign.source;
   if (campaign.medium) pageview.campaignMedium = campaign.medium;
   if (campaign.content) pageview.campaignContent = campaign.content;
   if (campaign.term) pageview.campaignKeyword = campaign.term;

--- a/lib/google-analytics/test.js
+++ b/lib/google-analytics/test.js
@@ -248,8 +248,8 @@ describe('Google Analytics', function(){
             page: '/path?q=1',
             title: 'category name',
             location: 'url',
-            campaignName: '(test)',
-            campaignSource: '(test)',
+            campaignName: 'test',
+            campaignSource: 'test',
             campaignMedium: "test",
             campaignKeyword: "test",
             campaignContent: "test"


### PR DESCRIPTION
See here: https://segment.zendesk.com/agent/tickets/20211

Mistakenly applied parens to campaign.name and campaign.source - removing those here.
