### PR TITLE
add support for bing ads universal event tracking

### DIFF
--- a/lib/bing-ads/index.js
+++ b/lib/bing-ads/index.js
@@ -30,10 +30,26 @@ var noop = function(){};
  */
 
 var Bing = module.exports = integration('Bing Ads')
+  .global('uetq')
+  .option('tagId', '')
   .option('siteId', '')
   .option('domainId', '')
-  .tag('<script id="mstag_tops" src="//flex.msn.com/mstag/site/{{ siteId }}/mstag.js">')
+  .tag('universal','<script src="//bat.bing.com/bat.js">')
+  .tag('campaign','<script id="mstag_tops" src="//flex.msn.com/mstag/site/{{ siteId }}/mstag.js">')
   .mapping('events');
+
+/**
+ * On `construct` swap any config-based methods to the proper implementation.
+ */
+
+Bing.on('construct', function(integration){
+  if (integration.options.universal) {
+    integration.initialize = integration.initializeUniversal;
+    integration.loaded = integration.loadedUniversal;
+    integration.track = integration.trackUniversal;
+    integration.page = integration.pageUniversal;
+  }
+});
 
 /**
  * Initialize.
@@ -57,7 +73,7 @@ Bing.prototype.initialize = function(page){
   };
   var self = this;
   onbody(function(){
-    self.load(function(){
+    self.load('campaign', function(){
       var loaded = bind(self, self.loaded);
 
       // poll until this.loaded() is true.
@@ -99,6 +115,68 @@ Bing.prototype.track = function(track){
     });
   });
 };
+
+/**
+ * Initialize (Universal)
+ *
+ * inferred from their snippet
+ * https://gist.github.com/sperand-io/8bef4207e9c66e1aa83b
+ */
+
+Bing.prototype.initializeUniversal = function(){
+  var self = this;
+  window.uetq = window.uetq || [];
+  self.load('universal', function(){
+    var setup = {
+      ti: self.options.tagId,
+      q: window.uetq
+    };
+    window.uetq = new UET(setup);
+    self.ready();
+  });
+};
+
+/**
+ * Loaded? (Universal)
+ *
+ * Check for custom `push` method bestowed by UET constructor
+ *
+ * @return {Boolean}
+ */
+
+Bing.prototype.loadedUniversal = function(){
+  return !! (window.uetq && window.uetq.push !== Array.prototype.push);
+};
+
+/**
+ * Page (Universal)
+ */
+
+Bing.prototype.pageUniversal = function(){
+  window.uetq.push("pageLoad");
+};
+
+/**
+ * Track (Universal)
+ *
+ * Doesn't take a mapping - send all events then set goals based
+ * on them retroactively: http://advertise.bingads.microsoft.com/en-us/uahelp-topic?market=en&project=Bing_Ads&querytype=topic&query=HLP_BA_PROC_UET.htm
+ *
+ * @param {Track} track
+ */
+
+Bing.prototype.trackUniversal = function(track){
+  var event = {
+    ea : 'track',
+    el : track.event()
+  };
+
+  if (track.category()) event.ec = track.category();
+  if (track.revenue()) event.ev = track.revenue();
+
+  window.uetq.push(event);
+};
+
 
 /**
  * Convert `document.write` to `document.appendChild`.

--- a/lib/bing-ads/index.js
+++ b/lib/bing-ads/index.js
@@ -32,143 +32,63 @@ var noop = function(){};
 var Bing = module.exports = integration('Bing Ads')
   .global('uetq')
   .option('tagId', '')
-  .option('siteId', '')
-  .option('domainId', '')
-  .tag('universal','<script src="//bat.bing.com/bat.js">')
-  .tag('campaign','<script id="mstag_tops" src="//flex.msn.com/mstag/site/{{ siteId }}/mstag.js">')
-  .mapping('events');
+  .tag('<script src="//bat.bing.com/bat.js">');
 
 /**
- * On `construct` swap any config-based methods to the proper implementation.
- */
-
-Bing.on('construct', function(integration){
-  if (integration.options.universal) {
-    integration.initialize = integration.initializeUniversal;
-    integration.loaded = integration.loadedUniversal;
-    integration.track = integration.trackUniversal;
-    integration.page = integration.pageUniversal;
-  }
-});
-
-/**
- * Initialize.
- *
- * http://msdn.microsoft.com/en-us/library/bing-ads-campaign-management-campaign-analytics-scripts.aspx
- *
- * @param {Object} page
- */
-
-Bing.prototype.initialize = function(page){
-  if (!window.mstag) {
-    window.mstag = {
-      loadTag: noop,
-      time: (new Date()).getTime(),
-      // they use document.write, which doesn't work when loaded async.
-      // they provide a way to override it.
-      // the first time it is called, load the script,
-      // and only when that script is done, is "loading" done.
-      _write: writeToAppend
-    };
-  };
-  var self = this;
-  onbody(function(){
-    self.load('campaign', function(){
-      var loaded = bind(self, self.loaded);
-
-      // poll until this.loaded() is true.
-      // have to do a weird hack like this because
-      // the first script loads a second script,
-      // and only after the second script is it actually loaded.
-      when(loaded, self.ready);
-    });
-  });
-};
-
-/**
- * Loaded?
- *
- * @return {Boolean}
- */
-
-Bing.prototype.loaded = function(){
-  return !! (window.mstag && window.mstag.loadTag !== noop);
-};
-
-/**
- * Track.
- *
- * @param {Track} track
- */
-
-Bing.prototype.track = function(track){
-  var events = this.events(track.event());
-  var revenue = track.revenue() || 0;
-  var self = this;
-  each(events, function(goal){
-    window.mstag.loadTag('analytics', {
-      domainId: self.options.domainId,
-      revenue: revenue,
-      dedup: '1',
-      type: '1',
-      actionid: goal
-    });
-  });
-};
-
-/**
- * Initialize (Universal)
+ * Initialize
  *
  * inferred from their snippet
  * https://gist.github.com/sperand-io/8bef4207e9c66e1aa83b
  */
 
-Bing.prototype.initializeUniversal = function(){
-  var self = this;
+Bing.prototype.initialize = function(){
   window.uetq = window.uetq || [];
-  self.load('universal', function(){
+  var self = this;
+
+  self.load(function(){
     var setup = {
       ti: self.options.tagId,
       q: window.uetq
     };
+
     window.uetq = new UET(setup);
     self.ready();
   });
 };
 
 /**
- * Loaded? (Universal)
+ * Loaded?
  *
  * Check for custom `push` method bestowed by UET constructor
  *
  * @return {Boolean}
  */
 
-Bing.prototype.loadedUniversal = function(){
+Bing.prototype.loaded = function(){
   return !! (window.uetq && window.uetq.push !== Array.prototype.push);
 };
 
 /**
- * Page (Universal)
+ * Page
  */
 
-Bing.prototype.pageUniversal = function(){
+Bing.prototype.page = function(){
   window.uetq.push("pageLoad");
 };
 
 /**
- * Track (Universal)
+ * Track
  *
- * Doesn't take a mapping - send all events then set goals based
+ * Send all events then set goals based
  * on them retroactively: http://advertise.bingads.microsoft.com/en-us/uahelp-topic?market=en&project=Bing_Ads&querytype=topic&query=HLP_BA_PROC_UET.htm
  *
  * @param {Track} track
  */
 
-Bing.prototype.trackUniversal = function(track){
+Bing.prototype.track = function(track){
   var event = {
-    ea : 'track',
-    el : track.event()
+    ea: 'track',
+    el: track.event()
   };
 
   if (track.category()) event.ec = track.category();
@@ -176,25 +96,3 @@ Bing.prototype.trackUniversal = function(track){
 
   window.uetq.push(event);
 };
-
-
-/**
- * Convert `document.write` to `document.appendChild`.
- *
- * TODO: make into a component.
- *
- * @param {String} str
- */
-
-function writeToAppend(str) {
-  var first = document.getElementsByTagName('script')[0];
-  var el = domify(str);
-  // https://github.com/component/domify/issues/14
-  if ('script' == el.tagName.toLowerCase() && el.getAttribute('src')) {
-    var tmp = document.createElement('script');
-    tmp.src = el.getAttribute('src');
-    tmp.async = true;
-    el = tmp;
-  }
-  document.body.appendChild(el);
-}

--- a/lib/bing-ads/test.js
+++ b/lib/bing-ads/test.js
@@ -9,81 +9,152 @@ describe('Bing Ads', function(){
   var Bing = plugin;
   var bing;
   var analytics;
-  var options = {
-    siteId: 'fd080b41-0f80-421d-9f12-d6ba437e206d',
-    domainId: '2823204',
-    events: {
-      signup: 1,
-      login: 2,
-      play: 3
-    }
-  };
 
   beforeEach(function(){
     analytics = new Analytics;
-    bing = new Bing(options);
     analytics.use(plugin);
     analytics.use(tester);
-    analytics.add(bing);
+
   });
 
   afterEach(function(){
     analytics.restore();
     analytics.reset();
-    bing.reset();
     sandbox();
   });
 
-  it('should have the correct settings', function(){
-    analytics.compare(Bing, integration('Bing Ads')
-      .option('siteId', '')
-      .option('domainId', '')
-      .mapping('events'));
-  });
+  describe('Campaign', function(){
+    var options = {
+      siteId: 'fd080b41-0f80-421d-9f12-d6ba437e206d',
+      domainId: '2823204',
+      events: {
+        signup: 1,
+        login: 2,
+        play: 3
+      }
+    };
 
-  describe('loading', function(){
-    it('should load', function(done){
-      analytics.load(bing, done);
+    beforeEach(function(){
+      bing = new Bing(options);
+      analytics.add(bing);
+    });
+
+    afterEach(function(){
+      bing.reset();
+    });
+
+    it('should have the correct settings', function(){
+      analytics.compare(Bing, integration('Bing Ads')
+        .option('siteId', '')
+        .option('domainId', '')
+        .mapping('events'));
+    });
+
+    describe('loading', function(){
+      it('should load', function(done){
+        analytics.load(bing, done);
+      });
+    });
+
+    describe('after loading', function(){
+      beforeEach(function(done){
+        analytics.once('ready', done);
+        analytics.initialize();
+        analytics.page();
+      });
+
+      describe('#track', function(){
+        beforeEach(function(){
+          analytics.stub(window.mstag, 'loadTag');
+        });
+
+        it('should not send if goal is not defined', function(){
+          analytics.track('toString', {});
+          analytics.didNotCall(window.mstag.loadTag);
+        });
+
+        it('should send correctly', function(){
+          analytics.track('play', { revenue: 90 });
+          analytics.called(window.mstag.loadTag, 'analytics', {
+            domainId: options.domainId,
+            revenue: 90,
+            dedup: '1',
+            type: '1',
+            actionid: options.events.play
+          });
+        });
+
+        it('should support array events', function(){
+          bing.options.events = [{ key: 'event', value: 4 }];
+          analytics.track('event', { revenue: 99 });
+          analytics.called(window.mstag.loadTag, 'analytics', {
+            actionid: bing.options.events[0].value,
+            domainId: options.domainId,
+            revenue: 99,
+            dedup: '1',
+            type: '1'
+          });
+        });
+      });
     });
   });
 
-  describe('after loading', function(){
-    beforeEach(function(done){
-      analytics.once('ready', done);
-      analytics.initialize();
-      analytics.page();
+  describe('Universal', function(){
+    var options = {
+      universal: true,
+      tagId: '4002754'
+    };
+
+    beforeEach(function(){
+      bing = new Bing(options);
+      analytics.add(bing);
     });
 
-    describe('#track', function(){
-      beforeEach(function(){
-        analytics.stub(window.mstag, 'loadTag');
+    afterEach(function(){
+      bing.reset();
+    });
+
+    it('should have the correct settings', function(){
+      analytics.compare(Bing, integration('Bing Ads')
+        .option('tagId', ''));
       });
 
-      it('should not send if goal is not defined', function(){
-        analytics.track('toString', {});
-        analytics.didNotCall(window.mstag.loadTag);
+    describe('loading', function(){
+      it('should load', function(done){
+        analytics.load(bing, done);
+      });
+    });
+
+    describe('after loading', function(){
+      beforeEach(function(done){
+        analytics.once('ready', done);
+        analytics.initialize();
       });
 
-      it('should send correctly', function(){
-        analytics.track('play', { revenue: 90 });
-        analytics.called(window.mstag.loadTag, 'analytics', {
-          domainId: options.domainId,
-          revenue: 90,
-          dedup: '1',
-          type: '1',
-          actionid: options.events.play
+      describe('#page', function(){
+        beforeEach(function(){
+          analytics.stub(window.uetq, 'push');
+        });
+
+        it('should track pageviews', function(){
+          analytics.page();
+          analytics.called(window.uetq.push, 'pageLoad');
         });
       });
 
-      it('should support array events', function(){
-        bing.options.events = [{ key: 'event', value: 4 }];
-        analytics.track('event', { revenue: 99 });
-        analytics.called(window.mstag.loadTag, 'analytics', {
-          actionid: bing.options.events[0].value,
-          domainId: options.domainId,
-          revenue: 99,
-          dedup: '1',
-          type: '1'
+      describe('#track', function(){
+        beforeEach(function(){
+          analytics.stub(window.uetq, 'push');
+        });
+
+        it('should send correctly', function(){
+          analytics.track('play', { category: 'fun', revenue: 90 });
+          analytics.called(window.uetq.push, {
+            ea: 'track',
+            el: 'play',
+            ec: 'fun',
+            ev: 90
+          });
         });
       });
     });

--- a/lib/bing-ads/test.js
+++ b/lib/bing-ads/test.js
@@ -9,152 +9,65 @@ describe('Bing Ads', function(){
   var Bing = plugin;
   var bing;
   var analytics;
+  var options = {
+    tagId: '4002754'
+  };
 
   beforeEach(function(){
     analytics = new Analytics;
+    bing = new Bing(options);
     analytics.use(plugin);
     analytics.use(tester);
-
+    analytics.add(bing);
   });
 
   afterEach(function(){
     analytics.restore();
     analytics.reset();
+    bing.reset();
     sandbox();
   });
 
-  describe('Campaign', function(){
-    var options = {
-      siteId: 'fd080b41-0f80-421d-9f12-d6ba437e206d',
-      domainId: '2823204',
-      events: {
-        signup: 1,
-        login: 2,
-        play: 3
-      }
-    };
-
-    beforeEach(function(){
-      bing = new Bing(options);
-      analytics.add(bing);
+  it('should have the correct settings', function(){
+    analytics.compare(Bing, integration('Bing Ads')
+      .option('tagId', ''));
     });
 
-    afterEach(function(){
-      bing.reset();
-    });
-
-    it('should have the correct settings', function(){
-      analytics.compare(Bing, integration('Bing Ads')
-        .option('siteId', '')
-        .option('domainId', '')
-        .mapping('events'));
-    });
-
-    describe('loading', function(){
-      it('should load', function(done){
-        analytics.load(bing, done);
-      });
-    });
-
-    describe('after loading', function(){
-      beforeEach(function(done){
-        analytics.once('ready', done);
-        analytics.initialize();
-        analytics.page();
-      });
-
-      describe('#track', function(){
-        beforeEach(function(){
-          analytics.stub(window.mstag, 'loadTag');
-        });
-
-        it('should not send if goal is not defined', function(){
-          analytics.track('toString', {});
-          analytics.didNotCall(window.mstag.loadTag);
-        });
-
-        it('should send correctly', function(){
-          analytics.track('play', { revenue: 90 });
-          analytics.called(window.mstag.loadTag, 'analytics', {
-            domainId: options.domainId,
-            revenue: 90,
-            dedup: '1',
-            type: '1',
-            actionid: options.events.play
-          });
-        });
-
-        it('should support array events', function(){
-          bing.options.events = [{ key: 'event', value: 4 }];
-          analytics.track('event', { revenue: 99 });
-          analytics.called(window.mstag.loadTag, 'analytics', {
-            actionid: bing.options.events[0].value,
-            domainId: options.domainId,
-            revenue: 99,
-            dedup: '1',
-            type: '1'
-          });
-        });
-      });
+  describe('loading', function(){
+    it('should load', function(done){
+      analytics.load(bing, done);
     });
   });
 
-  describe('Universal', function(){
-    var options = {
-      universal: true,
-      tagId: '4002754'
-    };
-
-    beforeEach(function(){
-      bing = new Bing(options);
-      analytics.add(bing);
+  describe('after loading', function(){
+    beforeEach(function(done){
+      analytics.once('ready', done);
+      analytics.initialize();
     });
 
-    afterEach(function(){
-      bing.reset();
-    });
-
-    it('should have the correct settings', function(){
-      analytics.compare(Bing, integration('Bing Ads')
-        .option('tagId', ''));
+    describe('#page', function(){
+      beforeEach(function(){
+        analytics.stub(window.uetq, 'push');
       });
 
-    describe('loading', function(){
-      it('should load', function(done){
-        analytics.load(bing, done);
+      it('should track pageviews', function(){
+        analytics.page();
+        analytics.called(window.uetq.push, 'pageLoad');
       });
     });
 
-    describe('after loading', function(){
-      beforeEach(function(done){
-        analytics.once('ready', done);
-        analytics.initialize();
+    describe('#track', function(){
+      beforeEach(function(){
+        analytics.stub(window.uetq, 'push');
       });
 
-      describe('#page', function(){
-        beforeEach(function(){
-          analytics.stub(window.uetq, 'push');
-        });
-
-        it('should track pageviews', function(){
-          analytics.page();
-          analytics.called(window.uetq.push, 'pageLoad');
-        });
-      });
-
-      describe('#track', function(){
-        beforeEach(function(){
-          analytics.stub(window.uetq, 'push');
-        });
-
-        it('should send correctly', function(){
-          analytics.track('play', { category: 'fun', revenue: 90 });
-          analytics.called(window.uetq.push, {
-            ea: 'track',
-            el: 'play',
-            ec: 'fun',
-            ev: 90
-          });
+      it('should send correctly', function(){
+        analytics.track('play', { category: 'fun', revenue: 90 });
+        analytics.called(window.uetq.push, {
+          ea: 'track',
+          el: 'play',
+          ec: 'fun',
+          ev: 90
         });
       });
     });


### PR DESCRIPTION
tackles #454

See:
- [bing blog post](http://advertise.bingads.microsoft.com/en-us/blogpost/129483/bing-ads-blog/universal-event-tracking-a-new-and-improved-way-to-track-your-sites-activities-in-bing-ads) announcing the switch
- [How UET works](http://advertise.bingads.microsoft.com/en-us/uahelp-topic?market=en&project=Bing_Ads&querytype=topic&query=HLP_BA_CONC_UET.htm)
- [How to send goals with UET](http://advertise.bingads.microsoft.com/en-us/uahelp-topic?market=en&project=Bing_Ads&querytype=topic&query=HLP_BA_PROC_UET.htm) -- closest thing to docs. 
- [snippet](https://gist.github.com/sperand-io/8bef4207e9c66e1aa83b) --  they make you create a campaign just to get it 😡. i followed its lead for `.initializeUniversal()`

Notes / things you could potentially disagree with me on :
- I'm currently defaulting `event action` parameter (used for the literal action like "click", "hover", etc) to `"track"` because I think that's semantically cleanest (`event label` has the event name).
- I've omitted the `goal value` custom param since the events have a native `event value` and I can't make heads or tails of what the GV is even for. They use it for discount values in the docs as an example... but there's no way to convey in the interface what the property is. Maybe I'm missing something?¿?

**Needs before merging**: 
- [x] **metadata updates**
  - i assumed we'd add a "Use Universal Event Tracking" checkbox to upgrade to UET and a 'tagId' field to fill out when that happens
  - maybe a better approach would be to add a checkbox box for "Use The Old One" [sic] that for existing users defaults to true but for new users defaults to false? @calvinfo i'll pick your brain on this tomorrow. 
- [x] documentation for how to upgrade, explanation of the differences
  - The old one is like other conversion-based tools with event mappings
  - Now, you set up a "tag" (tracker) in the interface, use that tagId to automatically listen on site for page loads, visit durations, etc. _All_ events are sent to bing and you define goals in their interface based on page visited, duration, or custom events
- [x] youtube video walking through how to switch / benefits etc
- [x] perhaps some partnership efforts with bing? i think if we nail the above we can make this new system drastically easier to understand and use than they have... @samdup 

@amillet89 @harrietgrace @ndhoule @yields 
