### PR TITLE
fix amplitude campaign name

### DIFF
--- a/component.json
+++ b/component.json
@@ -44,7 +44,7 @@
     "yields/merge": "*",
     "yields/slug": "1.1.0",
     "yields/some": "1.0.0",
-    "yields/store": "1.0.0",
+    "yields/store": "1.0.1",
     "yields/send-json": "1.1.1",
     "component/cookie": "1.1.1",
     "visionmedia/batch": "0.5.0",

--- a/lib/amplitude/index.js
+++ b/lib/amplitude/index.js
@@ -118,5 +118,9 @@ Amplitude.prototype.setDomain = function(href){
 
 Amplitude.prototype.setGlobalUserProperties = function(query){
   var campaign = utm(query);
+  // switch name to campaign so it doesn't conflict with the user's name
+  var campaignName = campaign.name;
+  campaign.campaign = campaignName;
+  delete campaign.name;
   if (campaign) window.amplitude.setGlobalUserProperties(campaign);
 };

--- a/lib/amplitude/test.js
+++ b/lib/amplitude/test.js
@@ -95,7 +95,7 @@ describe('Amplitude', function(){
           var query = '?utm_source=source&utm_medium=medium&utm_term=term&utm_content=content&utm_campaign=name';
           analytics.spy(window.amplitude, 'setGlobalUserProperties');
           amplitude.setGlobalUserProperties(query);
-          analytics.called(window.amplitude.setGlobalUserProperties, {source:'source', medium:'medium', term:'term', content:'content', name:'name'});
+          analytics.called(window.amplitude.setGlobalUserProperties, {source:'source', medium:'medium', term:'term', content:'content', campaign:'name'});
         });
       });
     });


### PR DESCRIPTION
@amillet89 it looks like the UTM fix is propagating `name` alongside `Name` (for a user's actual name) so I changed it to use `campaign` instead. 

When I tried to make the test locally I got an odd error. Let's chat when you get a sec.

Error loading resource http://170430035.log.optimizely.com/event?a=170430035&d=170430035&y=false&src=js&n=http://localhost:54546/test/&u=oeu1415821532565r0.12179974280297756&wxhr=true&t=1415821532569&f=2120713709&g= (5). Details: Operation canceled
make: **\* [test] Error 1
