### PR TITLE
Send revenue and orderId to Perfect Audience when 'track' is called

### DIFF
--- a/lib/perfect-audience/index.js
+++ b/lib/perfect-audience/index.js
@@ -48,7 +48,23 @@ PerfectAudience.prototype.loaded = function(){
  */
 
 PerfectAudience.prototype.track = function(track){
-  push('track', track.event());
+  var total = track.total() || track.revenue();
+  var orderId = track.orderId();
+  var props = {};
+  var sendProps = false;
+  if (total) {
+    props.revenue = total;
+    sendProps = true;
+  }
+  if (orderId) {
+    props.orderId = orderId;
+    sendProps = true;
+  }
+  if (sendProps) {
+    push('track', track.event(), props);
+  } else {
+    push('track', track.event());
+  }
 };
 
 

--- a/lib/perfect-audience/test.js
+++ b/lib/perfect-audience/test.js
@@ -78,6 +78,14 @@ describe('Perfect Audience', function(){
         analytics.track('event');
         analytics.called(window._pq.push, ['track', 'event']);
       });
+
+      it('should send event and orderId, revenue properties when passed', function(){
+        analytics.track('event', {
+          orderId: '12345',
+          total: 30
+        });
+        analytics.called(window._pq.push, ['track', 'event', {orderId: '12345', revenue: 30}]);
+      });
     });
 
     describe('#viewedProduct', function(){


### PR DESCRIPTION
Hi there! We at Perfect Audience noticed after a customer request that there is a bug in our analytics.js integration. It appears it was rewritten earlier this year, and `track` no longer forwards properties (including, critically, revenue and orderId information).

This PR ensures revenue and orderId are forwarded to our `track` method when available from the properties object. Tests updated as well. Thanks!
