### PR TITLE
Clicky: map .name() to username

### DIFF
--- a/lib/clicky/index.js
+++ b/lib/clicky/index.js
@@ -72,7 +72,15 @@ Clicky.prototype.page = function(page){
 Clicky.prototype.identify = function(identify){
   window.clicky_custom = window.clicky_custom || {};
   window.clicky_custom.session = window.clicky_custom.session || {};
-  extend(window.clicky_custom.session, identify.traits());
+  var traits = identify.traits();
+
+  var username = identify.username();
+  var email = identify.email();
+  var name = identify.name();
+
+  if (username || email || name) traits.username = username || email || name;
+
+  extend(window.clicky_custom.session, traits);
 };
 
 /**

--- a/lib/clicky/test.js
+++ b/lib/clicky/test.js
@@ -102,6 +102,48 @@ describe('Clicky', function(){
         analytics.identify('id', { trait: true });
         analytics.deepEqual(window.clicky_custom.session, { id: 'id', trait: true });
       });
+
+      it('should set a `traits.username` to clicky username', function(){
+        analytics.identify('id', { trait: true, name: "Joe Jonas", username: "joejonas" });
+        analytics.deepEqual(window.clicky_custom.session, {
+          id: 'id',
+          trait: true,
+          username: "joejonas",
+          name: "Joe Jonas"
+        });
+      });
+
+      it('should set a `traits.email` to clicky username if !traits.username', function(){
+        analytics.identify('id', { trait: true, name: "Joe Jonas", email: "joe@jonas.com" });
+        analytics.deepEqual(window.clicky_custom.session, {
+          id: 'id',
+          trait: true,
+          username: "joe@jonas.com",
+          name: "Joe Jonas",
+          email: "joe@jonas.com"
+        });
+      });
+
+      it('should set a `traits.name` to clicky username', function(){
+        analytics.identify('id', { trait: true, name: "Joe Jonas" });
+        analytics.deepEqual(window.clicky_custom.session, {
+          id: 'id',
+          trait: true,
+          username: "Joe Jonas",
+          name: "Joe Jonas"
+        });
+      });
+
+      it('should set use traits.firstName, traits.lastName', function(){
+        analytics.identify('id', { trait: true, firstName: "Joe", lastName: "Jonas" });
+        analytics.deepEqual(window.clicky_custom.session, {
+          id: 'id',
+          trait: true,
+          username: "Joe Jonas",
+          firstName: "Joe",
+          lastName: "Jonas"
+        });
+      });
     });
 
     describe('#track', function(){


### PR DESCRIPTION
The _only_ way to label your users with a meaningful name in Clicky is to pass a "username" property in their `clicky_custom.visitor` / `clicky_custom.session`  (same thing) object:

![](https://cldup.com/u9h_9Bo1-L.png)

this was brought to our attention by a user, [ticket here](https://segment.zendesk.com/agent/tickets/20280) and I think it makes sense for within clicky to map `identify.name()` to username so that users can make the most of the tool without having to pass a redundant 'username' trait to their other tools.

@amillet @harrietgrace @ndhoule 

lmk what you think! also, if there's a better way w/ js to trim the `name` values than `delete` i'm open to some code review haha.
