### PR TITLE
leadlander: support HTTPS

### DIFF
--- a/lib/leadlander/index.js
+++ b/lib/leadlander/index.js
@@ -4,6 +4,7 @@
  */
 
 var integration = require('analytics.js-integration');
+var useHttps = require('use-https');
 
 /**
  * Expose `LeadLander` integration.
@@ -11,10 +12,10 @@ var integration = require('analytics.js-integration');
 
 var LeadLander = module.exports = integration('LeadLander')
   .assumesPageview()
-  .global('llactid')
+  .global('tl813v')
   .global('trackalyzer')
   .option('accountId', null)
-  .tag('<script src="http://t6.trackalyzer.com/trackalyze-nodoc.js">');
+  .tag('<script src="//1.tl813.com/tl813.js">');
 
 /**
  * Initialize.
@@ -23,8 +24,8 @@ var LeadLander = module.exports = integration('LeadLander')
  */
 
 LeadLander.prototype.initialize = function(page){
-  window.llactid = this.options.accountId;
-  this.load(this.ready);
+  window.tl813v = this.options.accountId;
+  this.load(name, this.ready);
 };
 
 /**

--- a/lib/leadlander/test.js
+++ b/lib/leadlander/test.js
@@ -31,7 +31,7 @@ describe('LeadLander', function(){
   it('should have the right settings', function(){
     analytics.compare(LeadLander, integration('LeadLander')
       .assumesPageview()
-      .global('llactid')
+      .global('tl813v')
       .global('trackalyzer')
       .option('accountId', null));
   });
@@ -42,10 +42,10 @@ describe('LeadLander', function(){
     });
 
     describe('#initialize', function(){
-      it('should set window.llactid', function(){
+      it('should set window.tl813v', function(){
         analytics.initialize();
         analytics.page();
-        analytics.assert(window.llactid === options.accountId);
+        analytics.assert(window.tl813v === options.accountId);
       });
 
       it('should call #load', function(){


### PR DESCRIPTION
new snippet uses a different global and supports https: http://www.leadlander.com/trackingcode.html?id=26868

this change just moves to that new snippet. see ticket here: https://segment.zendesk.com/agent/tickets/21480

@amillet89 @yields 
