### PR TITLE
adding basic implementation of authors and sections

### DIFF
--- a/lib/chartbeat/index.js
+++ b/lib/chartbeat/index.js
@@ -62,6 +62,10 @@ Chartbeat.prototype.loaded = function(){
  */
 
 Chartbeat.prototype.page = function(page){
+  var category = page.category();
+  if (category) window._sf_async_config.sections = category;
+  var author = page.proxy('properties.author');
+  if (author) window._sf_async_config.authors = author;
   var props = page.properties();
   var name = page.fullName();
   window.pSUPERFLY.virtualPage(props.path, name || props.title);

--- a/lib/chartbeat/test.js
+++ b/lib/chartbeat/test.js
@@ -116,6 +116,13 @@ describe('Chartbeat', function(){
         analytics.page('Category', 'Name', { path: '/path', title: 'title' });
         analytics.called(window.pSUPERFLY.virtualPage, '/path', 'Category Name');
       });
+
+      it('should set the sections on the config', function(){
+        analytics.page('Category', 'Name', { path: '/path', title: 'title', author: 'Apple Potamus' });
+        analytics.equal('Category', window._sf_async_config.sections);
+        analytics.equal('Apple Potamus', window._sf_async_config.authors);
+        analytics.called(window.pSUPERFLY.virtualPage, '/path', 'Category Name');
+      });
     });
   });
 });


### PR DESCRIPTION
cc @amillet89 

https://chartbeat.com/docs/configuration_variables/#groups

goal is to add `sections` and `authors` parameters so that views can be easily sliced in chartbeat by those variables. `sections` maps neatly to `category`. i'm unsure about the `authors` spec since we don't have a dedicated property per se for `properties.author` on a `.page()` call...
