### PR TITLE
Google Analytics: add custom dims and metrics to track calls

### DIFF
--- a/lib/google-analytics/index.js
+++ b/lib/google-analytics/index.js
@@ -212,6 +212,10 @@ GA.prototype.track = function(track, options){
   var props = track.properties();
   var campaign = track.proxy('context.campaign') || {};
 
+  // custom dimensions & metrics
+  var custom = metrics(props, interfaceOpts);
+  if (length(custom)) window.ga('set', custom);
+
   var payload = {
     eventAction: track.event(),
     eventCategory: props.category || this._category || 'All',

--- a/lib/google-analytics/test.js
+++ b/lib/google-analytics/test.js
@@ -463,6 +463,18 @@ describe('Google Analytics', function(){
             nonInteraction: true
           })
         });
+
+        it('should map custom dimensions & metrics using track.properties()', function(){
+          ga.options.metrics = { loadTime: 'metric1', levelAchieved: 'metric2' };
+          ga.options.dimensions = { referrer: 'dimension2' };
+          analytics.track('Level Unlocked', { loadTime: '100', levelAchieved:'5', referrer: 'Google' });
+
+          analytics.called(window.ga, 'set', {
+            metric1: '100',
+            metric2: '5',
+            dimension2: 'Google'
+          });
+        });
       });
 
       describe('ecommerce', function(){


### PR DESCRIPTION
@sperand-io @ndhoule @harrietgrace @calvinfo 

This tackles https://github.com/segmentio/analytics.js-integrations/issues/456

It adds the ability to send along custom dimensions and properties that are passed through track calls. 
