### PR TITLE
Adroll: adding custom params

### DIFF
--- a/lib/adroll/index.js
+++ b/lib/adroll/index.js
@@ -8,6 +8,7 @@ var snake = require('to-snake-case');
 var useHttps = require('use-https');
 var each = require('each');
 var is = require('is');
+var del = require('obj-case').del;
 
 /**
  * HOP
@@ -83,6 +84,7 @@ AdRoll.prototype.track = function(track){
   var events = this.events(event);
   var total = track.revenue() || track.total() || 0;
   var orderId = track.orderId() || 0;
+  var customProps = track.properties();
 
   each(events, function(event){
     var data = {};
@@ -92,6 +94,12 @@ AdRoll.prototype.track = function(track){
     // the adroll interface only allows for
     // segment names which are snake cased.
     data.adroll_segments = snake(event);
+
+    del(customProps, "revenue");
+    del(customProps, "total");
+    del(customProps, "orderId");
+
+    if (!is.empty(customProps)) data.adroll_custom_data = customProps;
     window.__adroll.record_user(data);
   });
 

--- a/lib/adroll/test.js
+++ b/lib/adroll/test.js
@@ -202,6 +202,16 @@ describe('AdRoll', function(){
           });
         });
 
+        it('should pass custom data like product id and sku', function(){
+          analytics.track('event', { revenue: 2.99, id: '12345', sku: '43434-21' });
+          analytics.called(window.__adroll.record_user, {
+            adroll_segments: 'segment',
+            adroll_conversion_value_in_dollars: 2.99,
+            adroll_custom_data: { id: '12345', sku: '43434-21' },
+            order_id: '12345'
+          });
+        });
+
         it('should support array events', function(){
           adroll.options.events = [{ key: 'event', value: 'pixel' }];
           analytics.track('event', { total: 2.99, orderId: 2 });


### PR DESCRIPTION
@harrietgrace @ndhoule 

Passing custom parameters through to Adroll for more granular reporting. Removing revenue, traits, orderId params from custom properties to prevent duplication since they have their own dedicated fields.
