### PR TITLE
Add GitHub IP range to known_hosts to prevent Duo error

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,7 @@ machine:
     version: 0.11
 dependencies:
   pre:
+    - echo "github.com,192.30.252.*,192.30.253.*,192.30.254.*,192.30.255.* ssh-rsa $(ssh-keyscan -t rsa github.com | cut -d ' ' -f 3-)" >> ~/.ssh/known_hosts
     - make
 test:
   override:


### PR DESCRIPTION
https://help.github.com/articles/what-ip-addresses-does-github-use-that-i-should-whitelist/
