### PR TITLE
Quantcast: Adding custom label support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test: build.js test-style
 
 test-browser: build.js
 	@node bin/tests
-	@node_modules/.bin/duo-test browser --commands "make default" $(tests)
+	@node_modules/.bin/duo-test browser --commands "make" $(tests)
 
 test-sauce: node_modules build.js
 	@node bin/tests

--- a/component.json
+++ b/component.json
@@ -58,7 +58,8 @@
     "segmentio/replace-document-write": "1.0.1",
     "component/object": "0.0.3",
     "segmentio/obj-case": "0.0.7",
-    "segmentio/json": "^1.0.0"
+    "segmentio/json": "^1.0.0",
+    "component/reduce": "1.0.1"
   },
   "development": {
     "component/jquery": "*",

--- a/lib/quantcast/index.js
+++ b/lib/quantcast/index.js
@@ -6,6 +6,8 @@
 var push = require('global-queue')('_qevents', { wrap: false });
 var integration = require('analytics.js-integration');
 var useHttps = require('use-https');
+var is = require('is');
+var reduce = require('reduce');
 
 /**
  * Expose `Quantcast` integration.
@@ -38,7 +40,7 @@ Quantcast.prototype.initialize = function(page){
   if (user.id()) settings.uid = user.id();
 
   if (page) {
-    settings.labels = this.labels('page', page.category(), page.name());
+    settings.labels = this._labels('page', page.category(), page.name());
   }
 
   push(settings);
@@ -69,10 +71,11 @@ Quantcast.prototype.page = function(page){
   var category = page.category();
   var name = page.name();
   var customLabels = page.proxy('properties.label')
+  var labels = this._labels('page', category, name, customLabels);
 
   var settings = {
     event: 'refresh',
-    labels: this.labels('page', category, name, customLabels),
+    labels: labels,
     qacct: this.options.pCode,
   };
   var user = this.analytics.user();
@@ -110,7 +113,7 @@ Quantcast.prototype.track = function(track){
   var name = track.event();
   var revenue = track.revenue();
   var customLabels = track.proxy('properties.label');
-  var labels = this.labels('event', name, customLabels);
+  var labels = this._labels('event', name, customLabels);
 
   var settings = {
     event: 'click',
@@ -135,11 +138,11 @@ Quantcast.prototype.completedOrder = function(track){
   var name = track.event();
   var revenue = track.total();
   var customLabels = track.proxy('properties.label')
-  var labels = this.labels('event', name, customLabels);
+  var labels = this._labels('event', name, customLabels);
   var category = track.category();
 
   if (this.options.advertise && category) {
-    labels += ',' + this.labels('pcat', category);
+    labels += ',' + this._labels('pcat', category);
   }
 
   var settings = {
@@ -171,20 +174,20 @@ Quantcast.prototype.completedOrder = function(track){
  * @api private
  */
 
-Quantcast.prototype.labels = function(type){
-  var args = [].slice.call(arguments, 1);
+Quantcast.prototype._labels = function(type){
+  var args = Array.prototype.slice.call(arguments, 1);
   var advertise = this.options.advertise;
-  var ret = [];
 
   if (advertise && 'page' == type) type = 'event';
   if (advertise) type = '_fp.' + type;
 
-  for (var i = 0; i < args.length; ++i) {
-    if (null == args[i]) continue;
-    var value = String(args[i]);
-    ret.push(value.replace(/, /g, ','));
-  }
+  var separator = advertise ? ' ' : '.';
+  var ret = reduce(args, function(ret, arg){
+    if (arg != null) {
+      ret.push(String(arg).replace(/, /g, ','));
+    }
+    return ret;
+  }, []).join(separator);
 
-  ret = advertise ? ret.join(' ') : ret.join('.');
   return [type, ret].join('.');
 };

--- a/lib/quantcast/index.js
+++ b/lib/quantcast/index.js
@@ -68,9 +68,13 @@ Quantcast.prototype.loaded = function(){
 Quantcast.prototype.page = function(page){
   var category = page.category();
   var name = page.name();
+  var customLabels = page.proxy('properties.label')
+
+  debugger;
+
   var settings = {
     event: 'refresh',
-    labels: this.labels('page', category, name),
+    labels: this.labels('page', category, name, customLabels),
     qacct: this.options.pCode,
   };
   var user = this.analytics.user();
@@ -107,11 +111,20 @@ Quantcast.prototype.identify = function(identify){
 Quantcast.prototype.track = function(track){
   var name = track.event();
   var revenue = track.revenue();
+  var customLabels = page.proxy('properties.label');
+  var labels = this.labels('event', name, customLabels);
+
+  debugger;
+  console.log('track labels', labels);
+  console.log('options pcode', this.options.pCode);
+
   var settings = {
     event: 'click',
-    labels: this.labels('event', name),
+    labels: labels,
     qacct: this.options.pCode
   };
+
+  console.log('track settings', settings);
   var user = this.analytics.user();
   if (null != revenue) settings.revenue = (revenue+''); // convert to string
   if (user.id()) settings.uid = user.id();
@@ -128,7 +141,8 @@ Quantcast.prototype.track = function(track){
 Quantcast.prototype.completedOrder = function(track){
   var name = track.event();
   var revenue = track.total();
-  var labels = this.labels('event', name);
+  var customLabels = page.proxy('properties.label')
+  var labels = this.labels('event', name, customLabels);
   var category = track.category();
 
   if (this.options.advertise && category) {

--- a/lib/quantcast/index.js
+++ b/lib/quantcast/index.js
@@ -70,8 +70,6 @@ Quantcast.prototype.page = function(page){
   var name = page.name();
   var customLabels = page.proxy('properties.label')
 
-  debugger;
-
   var settings = {
     event: 'refresh',
     labels: this.labels('page', category, name, customLabels),
@@ -111,12 +109,8 @@ Quantcast.prototype.identify = function(identify){
 Quantcast.prototype.track = function(track){
   var name = track.event();
   var revenue = track.revenue();
-  var customLabels = page.proxy('properties.label');
+  var customLabels = track.proxy('properties.label');
   var labels = this.labels('event', name, customLabels);
-
-  debugger;
-  console.log('track labels', labels);
-  console.log('options pcode', this.options.pCode);
 
   var settings = {
     event: 'click',
@@ -124,7 +118,6 @@ Quantcast.prototype.track = function(track){
     qacct: this.options.pCode
   };
 
-  console.log('track settings', settings);
   var user = this.analytics.user();
   if (null != revenue) settings.revenue = (revenue+''); // convert to string
   if (user.id()) settings.uid = user.id();
@@ -141,7 +134,7 @@ Quantcast.prototype.track = function(track){
 Quantcast.prototype.completedOrder = function(track){
   var name = track.event();
   var revenue = track.total();
-  var customLabels = page.proxy('properties.label')
+  var customLabels = track.proxy('properties.label')
   var labels = this.labels('event', name, customLabels);
   var category = track.category();
 
@@ -189,7 +182,7 @@ Quantcast.prototype.labels = function(type){
   for (var i = 0; i < args.length; ++i) {
     if (null == args[i]) continue;
     var value = String(args[i]);
-    ret.push(value.replace(/,/g, ';'));
+    ret.push(value.replace(/, /g, ','));
   }
 
   ret = advertise ? ret.join(' ') : ret.join('.');

--- a/lib/quantcast/test.js
+++ b/lib/quantcast/test.js
@@ -127,6 +127,15 @@ describe('Quantcast', function(){
         });
       });
 
+      it('should add the properties labels to the label string', function(){
+        analytics.page('Category', 'Page', { label: 'TestLabel' });
+        analytics.called(window._qevents.push, {
+          event: 'refresh',
+          labels: 'page.Category.Page.TestLabel',
+          qacct: options.pCode
+        });
+      });
+
       it('should push the user id', function(){
         analytics.user().identify('id');
         analytics.page();
@@ -162,6 +171,10 @@ describe('Quantcast', function(){
     });
 
     describe('#identify', function(){
+      beforeEach(function(){
+        analytics.stub(window._qevents, 'push');
+      });
+
       it('should update the user id', function(){
         analytics.identify('id');
         analytics.assert(window._qevents[0].uid === 'id');
@@ -178,6 +191,7 @@ describe('Quantcast', function(){
       });
 
       it('should push a click event', function(){
+        debugger;
         analytics.track('event');
         analytics.called(window._qevents.push, {
           event: 'click',
@@ -195,6 +209,16 @@ describe('Quantcast', function(){
           revenue: '10.45'
         });
       });
+
+      // it('should push custom labels for the event', function(){
+      //   analytics.track('event', { label: 'newLabel,OtherLables' });
+      //   analytics.called(window._qevents.push, {
+      //     event: 'click',
+      //     labels: 'event.event,newLabel,OtherLables',
+      //     qacct: options.pCode,
+      //     revenue: '10.45'
+      //   });
+      // });
 
       it('should push the user id', function(){
         analytics.user().identify('id');

--- a/lib/quantcast/test.js
+++ b/lib/quantcast/test.js
@@ -113,7 +113,7 @@ describe('Quantcast', function(){
         analytics.page('Page, Name');
         analytics.called(window._qevents.push, {
           event: 'refresh',
-          labels: 'page.Page; Name',
+          labels: 'page.Page,Name',
           qacct: options.pCode
         });
       });
@@ -175,6 +175,10 @@ describe('Quantcast', function(){
         analytics.stub(window._qevents, 'push');
       });
 
+      afterEach(function(){
+        analytics.restore();
+      });
+
       it('should update the user id', function(){
         analytics.identify('id');
         analytics.assert(window._qevents[0].uid === 'id');
@@ -186,12 +190,7 @@ describe('Quantcast', function(){
         analytics.stub(window._qevents, 'push');
       });
 
-      afterEach(function(){
-        analytics.restore();
-      });
-
       it('should push a click event', function(){
-        debugger;
         analytics.track('event');
         analytics.called(window._qevents.push, {
           event: 'click',
@@ -210,15 +209,14 @@ describe('Quantcast', function(){
         });
       });
 
-      // it('should push custom labels for the event', function(){
-      //   analytics.track('event', { label: 'newLabel,OtherLables' });
-      //   analytics.called(window._qevents.push, {
-      //     event: 'click',
-      //     labels: 'event.event,newLabel,OtherLables',
-      //     qacct: options.pCode,
-      //     revenue: '10.45'
-      //   });
-      // });
+      it('should push custom labels for the event', function(){
+        analytics.track('event', { label: 'newLabel,OtherLables' });
+        analytics.called(window._qevents.push, {
+          event: 'click',
+          labels: 'event.event.newLabel,OtherLables',
+          qacct: options.pCode
+        });
+      });
 
       it('should push the user id', function(){
         analytics.user().identify('id');

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ mocha.setup({
 
 describe('integrations', function(){
   it('should export our integrations', function(){
-    assert.equal(78, object.length(Integrations));
+    assert.equal(79, object.length(Integrations));
   });
 });
 


### PR DESCRIPTION
Support for adding extra labels in the properties object, and sending a comma separated list of labels to Quantcast.

Quantcast docs: https://www.quantcast.com/help/labeling-and-hierarchy
