### PR TITLE
Frontleaf: Removing assumed page view

### DIFF
--- a/lib/frontleaf/index.js
+++ b/lib/frontleaf/index.js
@@ -13,7 +13,6 @@ var is = require('is');
  */
 
 var Frontleaf = module.exports = integration('Frontleaf')
-  .assumesPageview()
   .global('_fl')
   .global('_flBaseUrl')
   .option('baseUrl', 'https://api.frontleaf.com')

--- a/lib/frontleaf/test.js
+++ b/lib/frontleaf/test.js
@@ -32,7 +32,6 @@ describe('Frontleaf', function(){
 
   it('should have the right settings', function(){
     analytics.compare(Frontleaf, integration('Frontleaf')
-      .assumesPageview()
       .global('_fl')
       .global('_flBaseUrl')
       .option('token', '')


### PR DESCRIPTION
Removing assumesPageView from Frontleaf - they don't automatically send an event when the page loads. Per [this ticket](https://segment.zendesk.com/agent/tickets/22514).

@ndhoule 
