### PR TITLE
Fix/intercom date formatting

### DIFF
--- a/lib/intercom/index.js
+++ b/lib/intercom/index.js
@@ -6,6 +6,7 @@
 var integration = require('analytics.js-integration');
 var convertDates = require('convert-dates');
 var defaults = require('defaults');
+var del = require('obj-case').del;
 var isEmail = require('is-email');
 var load = require('load-script');
 var empty = require('is-empty');
@@ -94,14 +95,19 @@ Intercom.prototype.identify = function(identify){
   if (name) traits.name = name;
 
   // handle dates
-  if (traits.company && companyCreated) traits.company.created = companyCreated;
-  if (created) traits.created = created;
+  if (created) {
+    del(traits, 'created');
+    del(traits, 'createdAt');
+    traits.created_at = created;
+  }
+  if (companyCreated) {
+    del(traits.company, 'created');
+    del(traits.company, 'createdAt');
+    traits.company.created_at = companyCreated;
+  }
 
   // convert dates
   traits = convertDates(traits, formatDate);
-  traits = alias(traits, { createdAt: 'created' });
-  traits = alias(traits, { created: 'created_at' });
-  if (traits.company) traits.company = alias(traits.company, { created: 'created_at' });
 
   // handle options
   if (opts.increments) traits.increments = opts.increments;

--- a/lib/intercom/test.js
+++ b/lib/intercom/test.js
@@ -140,29 +140,75 @@ describe('Intercom', function(){
         });
       });
 
-      it('should send created_at as seconds', function(){
-        var now = new Date;
-        analytics.identify('id', { created: now });
-        analytics.called(window.Intercom, 'boot', {
-          app_id: options.appId,
-          created_at: Math.floor(now.getTime() / 1000),
-          user_id: 'id',
-          id: 'id'
-        });
-      });
+      describe('date handling', function(){
+        it('should accept `Date` instances', function(){
+          var date = new Date();
 
-      it('should convert dates', function(){
-        var date = new Date();
-        analytics.identify('id', {
-          created: date,
-          company: { created: date }
+          analytics.identify('id', {
+            created: date,
+            company: { created: date }
+          });
+
+          analytics.called(window.Intercom, 'boot', {
+            app_id: options.appId,
+            user_id: 'id',
+            created_at: Math.floor(date / 1000),
+            company: { created_at: Math.floor(date / 1000) },
+            id: 'id'
+          });
         });
-        analytics.called(window.Intercom, 'boot', {
-          app_id: options.appId,
-          user_id: 'id',
-          created_at: Math.floor(date / 1000),
-          company: { created_at: Math.floor(date / 1000) },
-          id: 'id'
+
+        it('should handle ISO datestrings', function() {
+          var date = new Date();
+          var isoDate = date.toISOString();
+          var unixDate = Math.floor(date / 1000);
+
+          analytics.identify('12345', {
+            createdAt: isoDate,
+            company: { created: isoDate }
+          });
+
+          analytics.called(window.Intercom, 'boot', {
+            app_id: options.appId,
+            user_id: '12345',
+            created_at: unixDate,
+            company: { created_at: unixDate },
+            id: '12345'
+          });
+        });
+
+        it('should accept Unix timestamps (in seconds)', function(){
+          var date = Math.floor(new Date().getTime() / 1000);
+
+          analytics.identify('12345', {
+            createdAt: date,
+            company: { created: date }
+          });
+
+          analytics.called(window.Intercom, 'boot', {
+            app_id: options.appId,
+            user_id: '12345',
+            created_at: date,
+            company: { created_at: date },
+            id: '12345'
+          });
+        });
+
+        it('should accept Unix timestamps (in milliseconds)', function(){
+          var date = new Date().getTime();
+
+          analytics.identify('12345', {
+            createdAt: date,
+            company: { created: date }
+          });
+
+          analytics.called(window.Intercom, 'boot', {
+            app_id: options.appId,
+            user_id: '12345',
+            created_at: Math.floor(date / 1000),
+            company: { created_at: Math.floor(date / 1000) },
+            id: '12345'
+          });
         });
       });
 
@@ -264,6 +310,7 @@ describe('Intercom', function(){
           }
         });
       });
+
       it('should work with .created_at', function(){
         analytics.group('id', { name: 'Name', createdAt: 'Jan 1, 2000 3:32:33 PM' });
         analytics.called(window.Intercom, 'update', {
@@ -274,6 +321,7 @@ describe('Intercom', function(){
           }
         });
       });
+
       it('should work with .created', function(){
         analytics.group('id', { name: 'Name', created: 'Jan 1, 2000 3:32:33 PM' });
         analytics.called(window.Intercom, 'update', {

--- a/lib/intercom/test.js
+++ b/lib/intercom/test.js
@@ -158,7 +158,7 @@ describe('Intercom', function(){
           });
         });
 
-        it('should handle ISO datestrings', function() {
+        it('should handle ISO datestrings', function(){
           var date = new Date();
           var isoDate = date.toISOString();
           var unixDate = Math.floor(date / 1000);


### PR DESCRIPTION
Mentioned this in Slack, but previously Unix timestamps (in milliseconds) were failing to go through to Intercom. (Intercom only accepts Unix stamps in seconds.)

This fixes that issue and generally simplifies date handling logic.

cc/ @amillet89 @harrietgrace 
