### PR TITLE
Add Extole integration

### DIFF
--- a/component.json
+++ b/component.json
@@ -57,7 +57,8 @@
     "segmentio/load-pixel": "0.1.1",
     "segmentio/replace-document-write": "1.0.1",
     "component/object": "0.0.3",
-    "segmentio/obj-case": "0.0.7"
+    "segmentio/obj-case": "0.0.7",
+    "segmentio/json": "^1.0.0"
   },
   "development": {
     "component/jquery": "*",

--- a/integrations.js
+++ b/integrations.js
@@ -26,6 +26,7 @@ module.exports = [
   require('./lib/drip'),
   require('./lib/errorception'),
   require('./lib/evergage'),
+  require('./lib/extole'),
   require('./lib/facebook-conversion-tracking'),
   require('./lib/foxmetrics'),
   require('./lib/frontleaf'),

--- a/lib/extole/index.js
+++ b/lib/extole/index.js
@@ -38,7 +38,7 @@ Extole.prototype.initialize = function(){
 */
 
 Extole.prototype.loaded = function(){
-  return !!(window.extole);
+  return !!window.extole;
 };
 
 /**
@@ -58,13 +58,13 @@ Extole.prototype.track = function(track){
   }
 
   var event = track.event();
-  var events = this.events(event);
+  var extoleEvents = this.events(event);
 
-  if (!events.length) {
+  if (!extoleEvents.length) {
     return this.debug('No events found for %s', event);
   }
 
-  each(events, bind(this, function(extoleEvent){
+  each(extoleEvents, bind(this, function(extoleEvent){
     this._registerConversion(createConversionTag({
       type: extoleEvent,
       params: formatConversionParams(event, email, userId, track.properties())
@@ -73,11 +73,10 @@ Extole.prototype.track = function(track){
 };
 
 /**
- * Create an Extole conversion tag.
+ * Register a conversion to Extole.
  *
  * @api private
- * @param {HTMLElement} conversionTag A HTML element containing an Extole
- * conversion.
+ * @param {HTMLElement} conversionTag An Extole conversion tag.
  */
 
 // TODO: If I understand Extole's lib correctly, this is sometimes async,

--- a/lib/extole/index.js
+++ b/lib/extole/index.js
@@ -1,0 +1,96 @@
+'use strict';
+
+/**
+* Module dependencies.
+*/
+
+var bind = require('bind');
+var each = require('each');
+var integration = require('analytics.js-integration');
+var formatConversionParams = require('./lib/formatConversionParams');
+var createConversionTag = require('./lib/createConversionTag');
+
+/**
+* Expose `Extole` integration.
+*/
+
+var Extole = module.exports = integration('Extole')
+  .global('extole')
+  .option('clientId', '')
+  .mapping('events')
+  .tag('main', '<script src="//tags.extole.com/{{ clientId }}/core.js">');
+
+/**
+* Initialize.
+*
+* @param {Object} page
+*/
+
+Extole.prototype.initialize = function(){
+  if (this.loaded()) return this.ready();
+  this.load('main', bind(this, this.ready));
+};
+
+/**
+* Loaded?
+*
+* @return {Boolean}
+*/
+
+Extole.prototype.loaded = function(){
+  return !!(window.extole);
+};
+
+/**
+* Track.
+*
+* @param {Track} track
+*/
+
+Extole.prototype.track = function(track){
+  var user = this.analytics.user();
+  var traits = user.traits();
+  var userId = user.id();
+  var email = traits.email;
+
+  if (!userId && !email) {
+    return this.debug('User must be identified before `#track` calls');
+  }
+
+  var event = track.event();
+  var events = this.events(event);
+
+  if (!events.length) {
+    return this.debug('No events found for %s', event);
+  }
+
+  each(events, bind(this, function(extoleEvent){
+    this._registerConversion(createConversionTag({
+      type: extoleEvent,
+      params: formatConversionParams(event, email, userId, track.properties())
+    }));
+  }));
+};
+
+/**
+ * Create an Extole conversion tag.
+ *
+ * @api private
+ * @param {HTMLElement} conversionTag A HTML element containing an Extole
+ * conversion.
+ */
+
+// TODO: If I understand Extole's lib correctly, this is sometimes async,
+// sometimes sync. Should probably refactor this into more predictable/sane
+// behavior
+Extole.prototype._registerConversion = function(conversionTag){
+  if (window.extole.main && window.extole.main.fireConversion) {
+    return window.extole.main.fireConversion(conversionTag);
+  }
+
+  if (window.extole.initializeGo) {
+    window.extole.initializeGo().andWhenItsReady(function(){
+      window.extole.main.fireConversion(conversionTag);
+    });
+  }
+};

--- a/lib/extole/lib/createConversionTag.js
+++ b/lib/extole/lib/createConversionTag.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+var domify = require('domify');
+var json = require('json');
+
+/**
+ * Create an Extole conversion tag.
+ *
+ * @param {Object} conversion An Extole conversion object.
+ * @return {HTMLElement}
+ */
+var createConversionTag = function(conversion){
+  return domify('<script type="extole/conversion">' + json.stringify(conversion) + '</script>');
+};
+
+/**
+ * Exports.
+ */
+
+module.exports = createConversionTag;

--- a/lib/extole/lib/formatConversionParams.js
+++ b/lib/extole/lib/formatConversionParams.js
@@ -1,0 +1,38 @@
+'use strict';
+/**
+ * Module dependencies.
+ */
+
+var extend = require('extend');
+
+/**
+ * formatConversionParams. Formats details from a Segment track event into a
+ * data format Extole can accept.
+ *
+ * @param {string} event
+ * @param {string} email
+ * @param {string|number} userId
+ * @param {Object} properties The result of calling `track.properties()`.
+ * @return {Object}
+ */
+var formatConversionParams = function(event, email, userId, properties){
+  var total;
+
+  if (properties.total) {
+    total = properties.total;
+    delete properties.total;
+    properties['tag:cart_value'] = total;
+  }
+
+  return extend({
+    'tag:segment_event': event,
+    e: email,
+    partner_conversion_id: userId
+  }, properties);
+};
+
+/**
+ * Exports.
+ */
+
+module.exports = formatConversionParams;

--- a/lib/extole/test.js
+++ b/lib/extole/test.js
@@ -1,0 +1,198 @@
+'use strict';
+
+var Analytics = require('analytics.js').constructor;
+var each = require('each');
+var integration = require('analytics.js-integration');
+var Extole = require('./');
+var sandbox = require('clear-env');
+var tester = require('analytics.js-integration-tester');
+var formatConversionParams = require('./lib/formatConversionParams');
+
+describe('Extole', function(){
+  var extole;
+  var analytics;
+  var options = {
+    clientId: 99286621,
+    events: {
+      'Completed Order': 'purchase',
+      'Completed Loan': 'purchase',
+      'Investment Made': 'purchase'
+    }
+  };
+
+  beforeEach(function(){
+    analytics = new Analytics();
+    extole = new Extole(options);
+    analytics.use(Extole);
+    analytics.use(tester);
+    analytics.add(extole);
+  });
+
+  afterEach(function(done){
+    function teardown() {
+      analytics.restore();
+      analytics.reset();
+      extole.reset();
+      sandbox();
+      done();
+    }
+
+    if (extole.loaded() && window.extole.main) {
+      return waitForWidgets(function(){
+        xtlTearDown();
+        teardown();
+      });
+    }
+
+    teardown();
+  });
+
+  it('should have the correct settings', function(){
+    analytics.compare(Extole, integration('Extole')
+      .global('extole')
+      .option('clientId', '')
+      .mapping('events'));
+  });
+
+  describe('before loading', function(){
+    beforeEach(function(){
+      analytics.spy(extole, 'load');
+    });
+
+    describe('#initialize', function(){
+      it('should call #load', function(){
+        analytics.initialize();
+        analytics.called(extole.load);
+      });
+    });
+  });
+
+  describe('loading', function(){
+    it('should load', function(done){
+      analytics.load(extole, done);
+    });
+
+    it('should create window.extole object when loaded', function(done){
+        analytics.assert(!window.extole);
+        analytics.load(extole, function(){
+          analytics.assert(window.extole);
+          done();
+        });
+    });
+  });
+
+  describe('after loading', function(){
+    beforeEach(function(done){
+      analytics.once('ready', function(){
+        window.extole.microsite ? done() : window.extole.initializeGo().andWhenItsReady(done);
+      });
+      analytics.initialize();
+    });
+
+    describe('#track', function(){
+      beforeEach(function(){
+        analytics.identify(12345, {
+          name: 'first last',
+          email: 'name@example.com'
+        });
+
+        analytics.stub(window.extole.main, 'fireConversion');
+      });
+
+      it('should track an event listed in the `events` mapping', function(){
+        analytics.track('Completed Loan', { total: 1.23 });
+        analytics.called(window.extole.main.fireConversion);
+      });
+
+      it('should track a different event', function(){
+        analytics.track('Completed Order', { total: 1.95 });
+        analytics.called(window.extole.main.fireConversion);
+      });
+
+      it('should not track an event that is not listed in the `events` mapping', function(){
+        analytics.track('Nonexistent', { craziness: 9.99 });
+        analytics.didNotCall(window.extole.main.fireConversion);
+      });
+    });
+
+    describe('data mapper', function(){
+      it('should convert `purchase` events to Extole\'s format', function(){
+        var userId = 12345;
+        var email = 'name@example.com';
+        var event = 'Completed Order';
+        var data = {
+          orderId: 12345,
+          total: 1.95,
+          products: [{
+            sku: 'fakesku',
+            quantity: 1,
+            price: 1.95,
+            name: 'fake-product',
+          }]
+        };
+        var expected = {
+          'tag:cart_value': 1.95,
+          'tag:segment_event': event,
+          e: email,
+          orderId: 12345,
+          partner_conversion_id: userId,
+          products: [{
+            sku: 'fakesku',
+            quantity: 1,
+            price: 1.95,
+            name: 'fake-product',
+          }]
+        };
+
+        analytics.deepEqual(formatConversionParams(event, email, userId, data), expected);
+      });
+    });
+  });
+});
+
+/**
+ * Extole setup/teardown helper functions.
+ */
+
+function waitForWidgets(cb, attempts){
+  window.extole.require(['jquery'], function($){
+    attempts = attempts || 70;
+    if (
+      attempts < 2 ||
+      ($('[id^="extole-advocate-widget"]')[0] &&
+      $('[id^="easyXDM_cloudsponge"]')[0] &&
+      $('#cs_container')[0] &&
+      $('#cs_link')[0])
+    ) {
+      window.setTimeout(cb, 200);
+    } else {
+      window.setTimeout(function(){
+        waitForWidgets(cb, attempts - 1);
+      }, 100);
+    }
+  });
+}
+
+function messageListenerOff(){
+  window.extole.require(['jquery'], function($){
+    var windowEvents = $._data($(window)[0], 'events');
+
+    each(windowEvents.message, function(msgEvent){
+      var msgNamespace;
+      if (msgEvent.namespace && msgEvent.namespace.match) {
+        if (msgNamespace = msgEvent.namespace.match(/^view\d+$/)){
+          $(window).off('message.' + msgNamespace);
+        }
+      }
+    });
+  });
+}
+
+function xtlTearDown(){
+  window.extole.require(['jquery'], function($){
+    var xtlSelectors = '[id^="extole-"], [id^="easyXDM_cloudsponge"], div[class^="extole"], #cs_container, #cs_link, #wrapped, #footer, style, link[href="https://api.cloudsponge.com/javascripts/address_books/floatbox.css"], link[href^="https://media.extole.com/"]';
+    $(xtlSelectors).remove();
+    delete window.cloudsponge;
+    messageListenerOff();
+  });
+}

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ mocha.setup({
 
 describe('integrations', function(){
   it('should export our integrations', function(){
-    assert.equal(74, object.length(Integrations));
+    assert.equal(75, object.length(Integrations));
   });
 });
 


### PR DESCRIPTION
Made a lot of changes based off #364 to get this into production shape. Notable among them was that the tests contained errors that prevented failure (most of them should have been failing but weren't), which precipitated a bunch of refactors. There are still things that can be simplified yet but it's ready for a v1 release.

@harrietgrace @amillet89, can you two have a look at this today? Aiming for a mid-day release, after I get back from an onsite at Prosper.

cc/ @pnorthup-extole

---
- Rebased Extole integration against 1.3.13. Switched to Domify for conversion tag. Supports lazy-loading widgets now.
- Made changes as per PR-364
- Fix async dependency load problem
- Style cleanups and refactors
- Fix formatting, syntax errors; remove unused deps
- User must be identified before track calls
- Fix silently failing tests
- Test fixup part 1
- Fixes:
  - Nullary property access in several places
  - Fix `events` mapping usage to match real-world input
- Make testing results easier
- Don't rely on library implementation internals causing test failures
- Consolidate duplicate tests
- Pass specs and remove unused code
- Remove unused dependency
- Simplify event teardown helper
- Further simplify teardown helpers
- Refactor out script insertion; replace with modular data formatter
  
  Appending a script to the page adds a lot of complexity to faciliate a task
  that is easily and better achieved via the console (debugging setup).
  This removes that step, and also moves the data mapping step out into a
  separate module, which allows us to decouple the data formatting out
  into an easily testable step.
  
  Since putting data in elements still tighly couples data to
  implementation details this isn't a perfect scenario, but dramatically
  improves testability and separation of concerns.
- Break libs out into files
- Flesh out future todo
