### PR TITLE
support trakio channels

### DIFF
--- a/lib/trakio/index.js
+++ b/lib/trakio/index.js
@@ -68,6 +68,8 @@ Trakio.prototype.page = function(page){
 
   window.trak.io.page_view(props.path, name || props.title);
 
+  if (category) window.trak.io.channel('category');
+
   // named pages
   if (name && this.options.trackNamedPages) {
     this.track(page.track(name));
@@ -126,7 +128,14 @@ Trakio.prototype.identify = function(identify){
  */
 
 Trakio.prototype.track = function(track){
-  window.trak.io.track(track.event(), track.properties());
+  var properties = track.properties();
+  var channel = track.proxy('properties.channel');
+  if (channel) {
+    delete properties.channel;
+    window.trak.io.track(track.event(), channel, properties);
+  } else {
+    window.trak.io.track(track.event(), properties);
+  }
 };
 
 /**

--- a/lib/trakio/test.js
+++ b/lib/trakio/test.js
@@ -78,6 +78,7 @@ describe('trak.io', function(){
       beforeEach(function(){
         analytics.stub(window.trak.io, 'page_view');
         analytics.stub(window.trak.io, 'track');
+        analytics.stub(window.trak.io, 'channel');
       });
 
       it('should call page_view', function(){
@@ -94,6 +95,11 @@ describe('trak.io', function(){
         analytics.page('name', { title: 'title' });
         analytics.called(window.trak.io.page_view, window.location.pathname, 'name');
       });
+
+      it('should map category to channel', function(){
+        analytics.page('category', 'name');
+         analytics.called(window.trak.io.channel, 'category');
+      })
 
       it('should prefer a category and name', function(){
         analytics.page('category', 'name', { title: 'title' });
@@ -171,6 +177,11 @@ describe('trak.io', function(){
       it('should send an event and properties', function(){
         analytics.track('event', { property: true });
         analytics.called(window.trak.io.track, 'event', { property: true });
+      });
+
+      it('should respect channel property', function(){
+        analytics.track('event', { property: true, channel: 'blog' });
+        analytics.called(window.trak.io.track, 'event', 'blog', { property: true });
       });
     });
 


### PR DESCRIPTION
Channel is pretty key in trak.io — can be set "globally" or overridden/set explicitly with each track call.

I think it makes sense to map our 'category' param in `page` to the global channel setting and then to respect a `channel` property in each `track` call for the override.

http://docs.trak.io/channel.html
http://docs.trak.io/track.html

thoughts? @amillet89 @harrietgrace @ndhoule 

closes  #487
