### PR TITLE
Piwik: adding custom variable support

### DIFF
--- a/component.json
+++ b/component.json
@@ -58,8 +58,7 @@
     "segmentio/replace-document-write": "1.0.1",
     "component/object": "0.0.3",
     "segmentio/obj-case": "0.0.7",
-    "segmentio/json": "^1.0.0",
-    "component/reduce": "1.0.1"
+    "segmentio/json": "^1.0.0"
   },
   "development": {
     "component/jquery": "*",

--- a/component.json
+++ b/component.json
@@ -58,7 +58,8 @@
     "segmentio/replace-document-write": "1.0.1",
     "component/object": "0.0.3",
     "segmentio/obj-case": "0.0.7",
-    "segmentio/json": "^1.0.0"
+    "segmentio/json": "^1.0.0",
+    "component/reduce": "1.0.1"
   },
   "development": {
     "component/jquery": "*",

--- a/lib/piwik/index.js
+++ b/lib/piwik/index.js
@@ -6,6 +6,7 @@
 var integration = require('analytics.js-integration');
 var push = require('global-queue')('_paq');
 var each = require('each');
+var is = require('is');
 
 /**
  * Expose `Piwik` integration.
@@ -63,9 +64,17 @@ Piwik.prototype.track = function(track){
   var action = track.event();
   var name = track.proxy('properties.name') || track.proxy('properties.label');
   var value = track.value() || track.revenue();
+  var customVars = track.proxy('properties.cvar') || track.proxy('properties.customVars');
 
   each(goals, function(goal){
     push('trackGoal', goal, revenue);
   });
+
+  if (!is.null(customVars) && !is.undefined(customVars)) {
+    each(customVars, function(key, valuePair){
+      push('setCustomVariable', key, valuePair[0], valuePair[1], 'page');
+    });
+  }
+
   push('trackEvent', category, action, name, value);
 };

--- a/lib/piwik/index.js
+++ b/lib/piwik/index.js
@@ -7,7 +7,7 @@ var integration = require('analytics.js-integration');
 var push = require('global-queue')('_paq');
 var each = require('each');
 var is = require('is');
-var reduce = require('reduce');
+var reduce = require('ianstormtaylor/reduce');
 
 /**
  * Expose `Piwik` integration.
@@ -68,29 +68,22 @@ Piwik.prototype.track = function(track){
   var value = track.value() || track.revenue();
 
   var options = track.options('Piwik');
-
-  // Add this if we enable setting your own customVariableLimit
-  //var customVariableLimit = this.options.customVariableLimit;
-
-  // Not currently enabling setting your own variable limit, setting this to the default
-  var customVariableLimit = 5;
-
+  var customVariableLimit = this.options.customVariableLimit || 5;
   var customVariables = options.customVars || options.cvar;
-  var formattedVars = {};
 
-  if (is.array(customVariables)) {
-    formattedVars = reduce(customVariables, function(formattedVars, value, i){
-      if (i <= customVariableLimit) formattedVars[i] = value;
-      return formattedVars;
-    }, {});
+  if (!is.object(customVariables) && !is.array(customVariables)) {
+    customVariables = [];
   }
 
-  if (is.object(customVariables)) formattedVars = customVariables;
+  if (is.object(customVariables)) {
+    customVariables = this._formatToArray(customVariables);
+  }
 
-  if (!is.null(formattedVars) && !is.undefined(formattedVars)) {
-    each(formattedVars, function(key, valuePair){
-      if (parseInt(key) <= customVariableLimit) push('setCustomVariable', key, valuePair[0], valuePair[1], 'page');
-    });
+  for (var i = 0; i < customVariableLimit; i += 1){
+    if (customVariables[i]) {
+      var varIndex = (i + 1).toString();
+      push('setCustomVariable', varIndex, customVariables[i][0], customVariables[i][1], 'page');
+    }
   }
 
   each(goals, function(goal){
@@ -98,4 +91,18 @@ Piwik.prototype.track = function(track){
   });
 
   push('trackEvent', category, action, name, value);
+};
+
+/**
+ * Helper method to format the custom variables.
+ *
+ * @param {Object} object
+ */
+
+Piwik.prototype._formatToArray = function(object){
+  return reduce(object, [], function(result, key, value){
+    key = parseInt(key, 10);
+    result.push(value);
+    return result;
+  });
 };

--- a/lib/piwik/index.js
+++ b/lib/piwik/index.js
@@ -7,6 +7,7 @@ var integration = require('analytics.js-integration');
 var push = require('global-queue')('_paq');
 var each = require('each');
 var is = require('is');
+var reduce = require('reduce');
 
 /**
  * Expose `Piwik` integration.
@@ -16,6 +17,7 @@ var Piwik = module.exports = integration('Piwik')
   .global('_paq')
   .option('url', null)
   .option('siteId', '')
+  .option('customVariableLimit', '')
   .mapping('goals')
   .tag('<script src="{{ url }}/piwik.js">');
 
@@ -64,17 +66,36 @@ Piwik.prototype.track = function(track){
   var action = track.event();
   var name = track.proxy('properties.name') || track.proxy('properties.label');
   var value = track.value() || track.revenue();
-  var customVars = track.proxy('properties.cvar') || track.proxy('properties.customVars');
+
+  var options = track.options('Piwik');
+
+  // Add this if we enable setting your own customVariableLimit
+  //var customVariableLimit = this.options.customVariableLimit;
+
+  // Not currently enabling setting your own variable limit, setting this to the default
+  var customVariableLimit = 5;
+
+  var customVariables = options.customVars || options.cvar;
+  var formattedVars = {};
+
+  if (is.array(customVariables)) {
+    formattedVars = reduce(customVariables, function(formattedVars, value, i){
+      if (i <= customVariableLimit) formattedVars[i] = value;
+      return formattedVars;
+    }, {});
+  }
+
+  if (is.object(customVariables)) formattedVars = customVariables;
+
+  if (!is.null(formattedVars) && !is.undefined(formattedVars)) {
+    each(formattedVars, function(key, valuePair){
+      if (parseInt(key) <= customVariableLimit) push('setCustomVariable', key, valuePair[0], valuePair[1], 'page');
+    });
+  }
 
   each(goals, function(goal){
     push('trackGoal', goal, revenue);
   });
-
-  if (!is.null(customVars) && !is.undefined(customVars)) {
-    each(customVars, function(key, valuePair){
-      push('setCustomVariable', key, valuePair[0], valuePair[1], 'page');
-    });
-  }
 
   push('trackEvent', category, action, name, value);
 };

--- a/lib/piwik/index.js
+++ b/lib/piwik/index.js
@@ -7,7 +7,6 @@ var integration = require('analytics.js-integration');
 var push = require('global-queue')('_paq');
 var each = require('each');
 var is = require('is');
-var reduce = require('ianstormtaylor/reduce');
 
 /**
  * Expose `Piwik` integration.
@@ -17,7 +16,7 @@ var Piwik = module.exports = integration('Piwik')
   .global('_paq')
   .option('url', null)
   .option('siteId', '')
-  .option('customVariableLimit', '')
+  .option('customVariableLimit', 5)
   .mapping('goals')
   .tag('<script src="{{ url }}/piwik.js">');
 
@@ -68,21 +67,15 @@ Piwik.prototype.track = function(track){
   var value = track.value() || track.revenue();
 
   var options = track.options('Piwik');
-  var customVariableLimit = this.options.customVariableLimit || 5;
   var customVariables = options.customVars || options.cvar;
 
-  if (!is.object(customVariables) && !is.array(customVariables)) {
-    customVariables = [];
+  if (!is.object(customVariables)) {
+    customVariables = {};
   }
 
-  if (is.object(customVariables)) {
-    customVariables = this._formatToArray(customVariables);
-  }
-
-  for (var i = 0; i < customVariableLimit; i += 1){
+  for (var i = 1; i <= this.options.customVariableLimit; i += 1){
     if (customVariables[i]) {
-      var varIndex = (i + 1).toString();
-      push('setCustomVariable', varIndex, customVariables[i][0], customVariables[i][1], 'page');
+      push('setCustomVariable', i.toString(), customVariables[i][0], customVariables[i][1], 'page');
     }
   }
 
@@ -91,18 +84,4 @@ Piwik.prototype.track = function(track){
   });
 
   push('trackEvent', category, action, name, value);
-};
-
-/**
- * Helper method to format the custom variables.
- *
- * @param {Object} object
- */
-
-Piwik.prototype._formatToArray = function(object){
-  return reduce(object, [], function(result, key, value){
-    key = parseInt(key, 10);
-    result.push(value);
-    return result;
-  });
 };

--- a/lib/piwik/test.js
+++ b/lib/piwik/test.js
@@ -11,7 +11,8 @@ describe('Piwik', function(){
   var analytics;
   var options = {
     siteId: 42,
-    url: 'https://demo.piwik.org'
+    url: 'https://demo.piwik.org',
+    customVariableLimit: 5
   };
 
   beforeEach(function(){
@@ -34,6 +35,7 @@ describe('Piwik', function(){
       .global('_paq')
       .option('siteId', '')
       .option('url', null)
+      .option('customVariableLimit', '')
       .mapping('goals'));
   });
 
@@ -121,25 +123,108 @@ describe('Piwik', function(){
       });
 
       it('should send one custom variable', function(){
-        analytics.track('event',
-          { cvar: {
-            1:["UserId","6116"]
-          }
-        });
+        analytics.track('event', { prop: true }, { integrations: { Piwik: { customVars: [["UserId","6116"]] } }});
         analytics.called(window._paq.push, ['setCustomVariable', '1', 'UserId', '6116', 'page']);
       });
 
-      it('should send multiple custom variables', function(){
+      it('should send multiple custom variables that get passed as an array', function(){
         analytics.track('event',
-          { cvar: {
-            1:["UserId","6116"],
-            2:["SubscriptionId",""],
-            3:["PlanName","ENTERPRISE"]
+          { prop: true },
+          { integrations: {
+              Piwik: {
+                customVars: [
+                  ["UserId","6116"],
+                  ['SubscriptionId', ''],
+                  ['PlanName', 'ENTERPRISE']
+                ]
+              }
+            }
           }
-        });
+        );
         analytics.called(window._paq.push, ['setCustomVariable', '1', 'UserId', '6116', 'page']);
         analytics.called(window._paq.push, ['setCustomVariable', '2', 'SubscriptionId', '', 'page']);
         analytics.called(window._paq.push, ['setCustomVariable', '3', 'PlanName', 'ENTERPRISE', 'page']);
+      });
+
+      it('should send multiple custom variables that get passed as cvar', function(){
+        analytics.track('event',
+          { prop: true },
+          { integrations: {
+              Piwik: {
+                cvar: [
+                  ["UserId","6116"],
+                  ['SubscriptionId', ''],
+                  ['PlanName', 'ENTERPRISE']
+                ]
+              }
+            }
+          }
+        );
+        analytics.called(window._paq.push, ['setCustomVariable', '1', 'UserId', '6116', 'page']);
+        analytics.called(window._paq.push, ['setCustomVariable', '2', 'SubscriptionId', '', 'page']);
+        analytics.called(window._paq.push, ['setCustomVariable', '3', 'PlanName', 'ENTERPRISE', 'page']);
+      });
+
+      it('should send multiple custom variables that get passed as an object', function(){
+        console.log('multiple vars as object');
+        analytics.track('event',
+          { prop: true },
+          { integrations: {
+              Piwik: {
+                customVars: {
+                  1: ["UserId","6116"],
+                  2: ['SubscriptionId', ''],
+                  3: ['PlanName', 'ENTERPRISE']
+                }
+              }
+            }
+          }
+        );
+        analytics.called(window._paq.push, ['setCustomVariable', '1', 'UserId', '6116', 'page']);
+        analytics.called(window._paq.push, ['setCustomVariable', '2', 'SubscriptionId', '', 'page']);
+        analytics.called(window._paq.push, ['setCustomVariable', '3', 'PlanName', 'ENTERPRISE', 'page']);
+      });
+
+      it('should\'t send custom variables that get passed in the wrong format', function(){
+        analytics.track('event', { prop: true }, { integrations: { Piwik: { customVars: { UserId:'6116' } } }});
+        analytics.didNotCall(window._paq.push, ['setCustomVariable', '1', 'UserId', '6116', 'page']);
+      });
+
+      it('should\'t send custom variables that are the wrong type', function(){
+        analytics.track('event', { prop: true }, { integrations: { Piwik: { customVars: { UserId: { Not: 'aNumber' }} } }});
+        analytics.didNotCall(window._paq.push, ['setCustomVariable', '1', 'UserId', { Not: 'aNumber' }, 'page']);
+      });
+
+      it('should\'t send custom variables that are empty', function(){
+        analytics.track('event', { prop: true }, { integrations: { Piwik: { customVars: { UserId:'' } } }});
+        analytics.didNotCall(window._paq.push, ['setCustomVariable', '1', 'UserId', '', 'page']);
+      });
+
+      it('shouldn\'t send more than the max number of custom variables', function(){
+        analytics.track('event',
+          { prop: true },
+          { integrations: {
+              Piwik: {
+                customVars: {
+                  1: ['UserId','6116'],
+                  2: ['SubscriptionId', ''],
+                  3: ['PlanName', 'ENTERPRISE'],
+                  4: ['New', 'item'],
+                  5: ['LastVariable', '0824'],
+                  6: ['TooManyVars', 'OhNo'],
+                  7: ['ThisIsntAThing', 'Apples']
+                }
+              }
+            }
+          }
+        );
+        analytics.called(window._paq.push, ['setCustomVariable', '1', 'UserId', '6116', 'page']);
+        analytics.called(window._paq.push, ['setCustomVariable', '2', 'SubscriptionId', '', 'page']);
+        analytics.called(window._paq.push, ['setCustomVariable', '3', 'PlanName', 'ENTERPRISE', 'page']);
+        analytics.called(window._paq.push, ['setCustomVariable', '4', 'New', 'item', 'page']);
+        analytics.called(window._paq.push, ['setCustomVariable', '5', 'LastVariable', '0824', 'page']);
+        analytics.didNotCall(window._paq.push, ['setCustomVariable', '6', 'TooManyVars', 'OhNo', 'page']);
+        analytics.didNotCall(window._paq.push, ['setCustomVariable', '7', 'ThisIsntAThing', 'Apples', 'page']);
       });
     });
   });

--- a/lib/piwik/test.js
+++ b/lib/piwik/test.js
@@ -11,8 +11,7 @@ describe('Piwik', function(){
   var analytics;
   var options = {
     siteId: 42,
-    url: 'https://demo.piwik.org',
-    customVariableLimit: 5
+    url: 'https://demo.piwik.org'
   };
 
   beforeEach(function(){
@@ -166,7 +165,6 @@ describe('Piwik', function(){
       });
 
       it('should send multiple custom variables that get passed as an object', function(){
-        console.log('multiple vars as object');
         analytics.track('event',
           { prop: true },
           { integrations: {
@@ -225,6 +223,34 @@ describe('Piwik', function(){
         analytics.called(window._paq.push, ['setCustomVariable', '5', 'LastVariable', '0824', 'page']);
         analytics.didNotCall(window._paq.push, ['setCustomVariable', '6', 'TooManyVars', 'OhNo', 'page']);
         analytics.didNotCall(window._paq.push, ['setCustomVariable', '7', 'ThisIsntAThing', 'Apples', 'page']);
+      });
+
+      it('should pick up the max variable setting change and send more than 5 variables', function(){
+        piwik.options.customVariableLimit = 10;
+        analytics.track('event',
+          { prop: true },
+          { integrations: {
+              Piwik: {
+                customVars: {
+                  1: ['UserId','6116'],
+                  2: ['SubscriptionId', ''],
+                  3: ['PlanName', 'ENTERPRISE'],
+                  4: ['New', 'item'],
+                  5: ['LastVariable', '0824'],
+                  6: ['TooManyVars', 'OhNo'],
+                  7: ['ThisIsntAThing', 'Apples']
+                }
+              }
+            }
+          }
+        );
+        analytics.called(window._paq.push, ['setCustomVariable', '1', 'UserId', '6116', 'page']);
+        analytics.called(window._paq.push, ['setCustomVariable', '2', 'SubscriptionId', '', 'page']);
+        analytics.called(window._paq.push, ['setCustomVariable', '3', 'PlanName', 'ENTERPRISE', 'page']);
+        analytics.called(window._paq.push, ['setCustomVariable', '4', 'New', 'item', 'page']);
+        analytics.called(window._paq.push, ['setCustomVariable', '5', 'LastVariable', '0824', 'page']);
+        analytics.called(window._paq.push, ['setCustomVariable', '6', 'TooManyVars', 'OhNo', 'page']);
+        analytics.called(window._paq.push, ['setCustomVariable', '7', 'ThisIsntAThing', 'Apples', 'page']);
       });
     });
   });

--- a/lib/piwik/test.js
+++ b/lib/piwik/test.js
@@ -34,7 +34,7 @@ describe('Piwik', function(){
       .global('_paq')
       .option('siteId', '')
       .option('url', null)
-      .option('customVariableLimit', '')
+      .option('customVariableLimit', 5)
       .mapping('goals'));
   });
 
@@ -122,27 +122,8 @@ describe('Piwik', function(){
       });
 
       it('should send one custom variable', function(){
-        analytics.track('event', { prop: true }, { integrations: { Piwik: { customVars: [["UserId","6116"]] } }});
+        analytics.track('event', { prop: true }, { integrations: { Piwik: { customVars: { 1: ["UserId","6116"] } } }});
         analytics.called(window._paq.push, ['setCustomVariable', '1', 'UserId', '6116', 'page']);
-      });
-
-      it('should send multiple custom variables that get passed as an array', function(){
-        analytics.track('event',
-          { prop: true },
-          { integrations: {
-              Piwik: {
-                customVars: [
-                  ["UserId","6116"],
-                  ['SubscriptionId', ''],
-                  ['PlanName', 'ENTERPRISE']
-                ]
-              }
-            }
-          }
-        );
-        analytics.called(window._paq.push, ['setCustomVariable', '1', 'UserId', '6116', 'page']);
-        analytics.called(window._paq.push, ['setCustomVariable', '2', 'SubscriptionId', '', 'page']);
-        analytics.called(window._paq.push, ['setCustomVariable', '3', 'PlanName', 'ENTERPRISE', 'page']);
       });
 
       it('should send multiple custom variables that get passed as cvar', function(){
@@ -150,11 +131,11 @@ describe('Piwik', function(){
           { prop: true },
           { integrations: {
               Piwik: {
-                cvar: [
-                  ["UserId","6116"],
-                  ['SubscriptionId', ''],
-                  ['PlanName', 'ENTERPRISE']
-                ]
+                cvar: {
+                  1: ["UserId","6116"],
+                  2: ['SubscriptionId', ''],
+                  3: ['PlanName', 'ENTERPRISE']
+                }
               }
             }
           }
@@ -164,7 +145,7 @@ describe('Piwik', function(){
         analytics.called(window._paq.push, ['setCustomVariable', '3', 'PlanName', 'ENTERPRISE', 'page']);
       });
 
-      it('should send multiple custom variables that get passed as an object', function(){
+      it('should send multiple custom variables that get passed as an customVars', function(){
         analytics.track('event',
           { prop: true },
           { integrations: {
@@ -198,7 +179,7 @@ describe('Piwik', function(){
         analytics.didNotCall(window._paq.push, ['setCustomVariable', '1', 'UserId', '', 'page']);
       });
 
-      it('shouldn\'t send more than the max number of custom variables', function(){
+      it('shouldn\t send more than the \'customVariableLimit\' number of variables', function(){
         analytics.track('event',
           { prop: true },
           { integrations: {
@@ -225,7 +206,7 @@ describe('Piwik', function(){
         analytics.didNotCall(window._paq.push, ['setCustomVariable', '7', 'ThisIsntAThing', 'Apples', 'page']);
       });
 
-      it('should pick up the max variable setting change and send more than 5 variables', function(){
+      it('should send up to the \'customVariableLimit\' number of variables', function(){
         piwik.options.customVariableLimit = 10;
         analytics.track('event',
           { prop: true },

--- a/lib/piwik/test.js
+++ b/lib/piwik/test.js
@@ -119,6 +119,28 @@ describe('Piwik', function(){
         analytics.track('Completed Order', { total: 20 });
         analytics.called(window._paq.push, ['trackGoal', 10, 20]);
       });
+
+      it('should send one custom variable', function(){
+        analytics.track('event',
+          { cvar: {
+            1:["UserId","6116"]
+          }
+        });
+        analytics.called(window._paq.push, ['setCustomVariable', '1', 'UserId', '6116', 'page']);
+      });
+
+      it('should send multiple custom variables', function(){
+        analytics.track('event',
+          { cvar: {
+            1:["UserId","6116"],
+            2:["SubscriptionId",""],
+            3:["PlanName","ENTERPRISE"]
+          }
+        });
+        analytics.called(window._paq.push, ['setCustomVariable', '1', 'UserId', '6116', 'page']);
+        analytics.called(window._paq.push, ['setCustomVariable', '2', 'SubscriptionId', '', 'page']);
+        analytics.called(window._paq.push, ['setCustomVariable', '3', 'PlanName', 'ENTERPRISE', 'page']);
+      });
     });
   });
 });


### PR DESCRIPTION
Updating Piwik to let people send custom variables. Sticking with the format that was requested by [this ticket](https://segment.zendesk.com/agent/tickets/22930):

```
{ cvar: {
    1:["UserId","898032"],
    2:["Things",""],
    3:["Names","Cool Beans"]
   }
 }
```

Sending it in this format on every call gives us two important features - a) you can specify particular indexes for each variable (something that piwik allows, and needs to be sent with every setCustomVariable call), and b) the ability to send different variables on each call which is something that we wouldn't get if we were getting users to add them through their dashboard settings. 

Piwik docs are [here](http://developer.piwik.org/guides/tracking-javascript-guide) and the custom vars section is about 1/3 of the way down the page.

@ndhoule 
