### PR TITLE
heap — remove assumes pageview

### DIFF
--- a/lib/heap/index.js
+++ b/lib/heap/index.js
@@ -11,7 +11,6 @@ var alias = require('alias');
  */
 
 var Heap = module.exports = integration('Heap')
-  .assumesPageview()
   .global('heap')
   .global('_heapid')
   .option('appId', '')

--- a/lib/heap/test.js
+++ b/lib/heap/test.js
@@ -31,7 +31,6 @@ describe('Heap', function(){
 
   it('should have the right settings', function(){
     analytics.compare(Heap, integration('Heap')
-      .assumesPageview()
       .global('heap')
       .global('_heapid')
       .option('appId', ''));
@@ -46,7 +45,6 @@ describe('Heap', function(){
       it('should create window.heap', function(){
         analytics.assert(!window.heap);
         analytics.initialize();
-        analytics.page();
         analytics.assert(window.heap);
       });
 
@@ -54,7 +52,6 @@ describe('Heap', function(){
         var methods = ['identify', 'track'];
         analytics.assert(!window.heap);
         analytics.initialize();
-        analytics.page();
         each(methods, function(method){
           analytics.assert(window.heap[method]);
         });
@@ -63,13 +60,11 @@ describe('Heap', function(){
       it('should set window._heapid', function(){
         analytics.assert(!window._heapid);
         analytics.initialize();
-        analytics.page();
         analytics.assert(window._heapid === options.appId);
       });
 
       it('should call #load', function(){
         analytics.initialize();
-        analytics.page();
         analytics.called(heap.load);
       });
     });


### PR DESCRIPTION
No need for it, as we don't map `page` calls
