### PR TITLE
Add mailchimp client-side tracking

### DIFF
--- a/integrations.js
+++ b/integrations.js
@@ -53,6 +53,7 @@ module.exports = [
   require('./lib/livechat'),
   require('./lib/lucky-orange'),
   require('./lib/lytics'),
+  require('./lib/mailchimp'),
   require('./lib/mixpanel'),
   require('./lib/mojn'),
   require('./lib/mouseflow'),

--- a/lib/mailchimp/index.js
+++ b/lib/mailchimp/index.js
@@ -1,0 +1,48 @@
+
+/**
+ * Module dependencies.
+ */
+
+var integration = require('analytics.js-integration');
+
+/**
+ * Expose Mailchimp integration.
+ */
+
+var Mailchimp = module.exports = integration('Mailchimp')
+  .assumesPageview()
+  .global('$mcGoal')
+  .option('uuid', null)
+  .option('dc', null)
+  .tag('<script src="//downloads.mailchimp.com/js/goal.min.js">');
+
+/**
+ * Initialize.
+ *
+ * @param {Object} page
+ */
+
+Mailchimp.prototype.initialize = function(page){
+  var self = this;
+
+  window.$mcGoal = {
+    settings: {
+      uuid: this.options.uuid,
+      dc: this.options.dc
+    }
+  };
+
+  console.log(window.$mcGoal);
+
+ this.load(this.ready);
+};
+
+/**
+ * Loaded?
+ *
+ * @return {Boolean}
+ */
+
+Mailchimp.prototype.loaded = function(){
+  return !! (window.$mcGoal && window.$mcGoal.process);
+};

--- a/lib/mailchimp/test.js
+++ b/lib/mailchimp/test.js
@@ -1,0 +1,70 @@
+
+var Analytics = require('analytics.js').constructor;
+var integration = require('analytics.js-integration');
+var tester = require('analytics.js-integration-tester');
+var plugin = require('./');
+var sandbox = require('clear-env');
+
+describe('Mailchimp', function(){
+  var Mailchimp = plugin;
+  var mailchimp;
+  var analytics;
+  var options = {
+    uuid: 'FOO',
+    dc: 'BAR'
+  };
+
+  beforeEach(function(){
+    analytics = new Analytics;
+    mailchimp = new Mailchimp(options);
+    analytics.use(plugin);
+    analytics.use(tester);
+    analytics.add(mailchimp);
+  });
+
+  afterEach(function(){
+    analytics.restore();
+    analytics.reset();
+    mailchimp.reset();
+    sandbox();
+  });
+
+  it('should have the right settings', function(){
+    analytics.compare(Mailchimp, integration('Mailchimp')
+      .assumesPageview()
+      .global('$mcGoal')
+      .option('uuid', null)
+      .option('dc', null));
+  });
+
+  describe('before loading', function(){
+    beforeEach(function(){
+      analytics.stub(mailchimp, 'load');
+    });
+
+    describe('#initialize', function(){
+      it('should create window.$mcGoal', function(){
+        analytics.initialize();
+        analytics.page();
+        analytics.deepEqual(window.$mcGoal, {
+          settings: {
+            uuid: options.uuid,
+            dc: options.dc
+          }
+        });
+      });
+
+      it('should call #load', function(){
+        analytics.initialize();
+        analytics.page();
+        analytics.called(mailchimp.load);
+      });
+    });
+  });
+
+  describe('loading', function(){
+    it('should load', function(done){
+      analytics.load(mailchimp, done);
+    });
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ mocha.setup({
 
 describe('integrations', function(){
   it('should export our integrations', function(){
-    assert.equal(80, object.length(Integrations));
+    assert.equal(81, object.length(Integrations));
   });
 });
 


### PR DESCRIPTION
> Goal is an optional campaign tracking feature available for paid accounts that lets you trigger Automation workflows based on subscriber activity from your automated emails to your website. The Goal integration can also be used to create segments that target subscribers based on their Goal activity.

[see full docs](http://kb.mailchimp.com/integrations/other-integrations/integrate-goal-with-mailchimp)

related to https://github.com/segmentio/integration-mailchimp/issues/3
