### PR TITLE
Quantcast: labels fix

### DIFF
--- a/lib/quantcast/index.js
+++ b/lib/quantcast/index.js
@@ -8,6 +8,7 @@ var integration = require('analytics.js-integration');
 var useHttps = require('use-https');
 var is = require('is');
 var reduce = require('reduce');
+var del = require('obj-case').del;
 
 /**
  * Expose `Quantcast` integration.
@@ -70,7 +71,7 @@ Quantcast.prototype.loaded = function(){
 Quantcast.prototype.page = function(page){
   var category = page.category();
   var name = page.name();
-  var customLabels = page.proxy('properties.label')
+  var customLabels = { label: page.proxy('properties.label') };
   var labels = this._labels('page', category, name, customLabels);
 
   var settings = {
@@ -112,7 +113,7 @@ Quantcast.prototype.identify = function(identify){
 Quantcast.prototype.track = function(track){
   var name = track.event();
   var revenue = track.revenue();
-  var customLabels = track.proxy('properties.label');
+  var customLabels = { label: track.proxy('properties.label') };
   var labels = this._labels('event', name, customLabels);
 
   var settings = {
@@ -137,7 +138,7 @@ Quantcast.prototype.track = function(track){
 Quantcast.prototype.completedOrder = function(track){
   var name = track.event();
   var revenue = track.total();
-  var customLabels = track.proxy('properties.label')
+  var customLabels = { label: track.proxy('properties.label') };
   var labels = this._labels('event', name, customLabels);
   var category = track.category();
 
@@ -177,17 +178,25 @@ Quantcast.prototype.completedOrder = function(track){
 Quantcast.prototype._labels = function(type){
   var args = Array.prototype.slice.call(arguments, 1);
   var advertise = this.options.advertise;
+  var separator = advertise ? ' ' : '.';
+  var customVars;
 
   if (advertise && 'page' == type) type = 'event';
   if (advertise) type = '_fp.' + type;
 
-  var separator = advertise ? ' ' : '.';
   var ret = reduce(args, function(ret, arg){
-    if (arg != null) {
+    if (is.object(arg) && arg.label) {
+      customVars = arg.label;
+    }
+
+    if (arg != null && !is.object(arg)) {
       ret.push(String(arg).replace(/, /g, ','));
     }
     return ret;
   }, []).join(separator);
 
-  return [type, ret].join('.');
+  var labels = [type, ret].join('.');
+  if (customVars) labels = [labels, customVars].join(',');
+
+  return labels;
 };

--- a/lib/quantcast/index.js
+++ b/lib/quantcast/index.js
@@ -41,7 +41,7 @@ Quantcast.prototype.initialize = function(page){
   if (user.id()) settings.uid = user.id();
 
   if (page) {
-    settings.labels = this._labels('page', page.category(), page.name());
+    settings.labels = createLabels('page', [page.category(), page.name()]);
   }
 
   push(settings);
@@ -71,8 +71,22 @@ Quantcast.prototype.loaded = function(){
 Quantcast.prototype.page = function(page){
   var category = page.category();
   var name = page.name();
-  var customLabels = { label: page.proxy('properties.label') };
-  var labels = this._labels('page', category, name, customLabels);
+
+  var prefix = 'page';
+  if (this.options.advertise) prefix = joinLabels(['_fp', 'event'], '.');
+
+  var options = page.options('Quantcast');
+  var customLabels = options.labels;
+  if (!is.array(customLabels) && is.string(customLabels)) {
+    customLabels = [customLabels];
+  }
+
+  var pageMeta = [];
+
+  if (category) pageMeta.push(category);
+  if (name) pageMeta.push(name);
+
+  var labels = createLabels(prefix, pageMeta, customLabels);
 
   var settings = {
     event: 'refresh',
@@ -113,8 +127,19 @@ Quantcast.prototype.identify = function(identify){
 Quantcast.prototype.track = function(track){
   var name = track.event();
   var revenue = track.revenue();
-  var customLabels = { label: track.proxy('properties.label') };
-  var labels = this._labels('event', name, customLabels);
+
+  var options = track.options('Quantcast');
+  var customLabels = options.labels;
+  if (!is.array(customLabels) && is.string(customLabels)) {
+    customLabels = [customLabels];
+  }
+
+  var prefix = 'event';
+  if (this.options.advertise) prefix = joinLabels(['_fp', prefix], '.');
+
+  var pageMeta = name ? [name] : null;
+
+  var labels = createLabels(prefix, pageMeta, customLabels);
 
   var settings = {
     event: 'click',
@@ -138,12 +163,24 @@ Quantcast.prototype.track = function(track){
 Quantcast.prototype.completedOrder = function(track){
   var name = track.event();
   var revenue = track.total();
-  var customLabels = { label: track.proxy('properties.label') };
-  var labels = this._labels('event', name, customLabels);
+
   var category = track.category();
 
+  var options = track.options('Quantcast');
+  var customLabels = options.labels;
+  if (!is.array(customLabels) && is.string(customLabels)) {
+    customLabels = [customLabels];
+  }
+
+  var prefix = 'event';
+  if (this.options.advertise) prefix = joinLabels(['_fp', prefix], '.');
+
+  var pageMeta = name ? [name] : null;
+  var labels = createLabels(prefix, pageMeta, customLabels);
+
   if (this.options.advertise && category) {
-    labels += ',' + this._labels('pcat', category);
+    var extraPcatLabel = createLabels('_fp.pcat', [category]);
+    labels = joinLabels([labels, extraPcatLabel], ',');
   }
 
   var settings = {
@@ -157,46 +194,37 @@ Quantcast.prototype.completedOrder = function(track){
 };
 
 /**
- * Generate quantcast labels.
+ * Helper method to generate quantcast labels.
  *
- * Example:
- *
- *    options.advertise = false;
- *    labels('event', 'my event');
- *    // => "event.my event"
- *
- *    options.advertise = true;
- *    labels('event', 'my event');
- *    // => "_fp.event.my event"
- *
- * @param {String} type
- * @param {String} ...
+ * @param {String} prefix
+ * @param {Array} pageMeta
+ * @param {Array} ...
  * @return {String}
  * @api private
  */
 
-Quantcast.prototype._labels = function(type){
-  var args = Array.prototype.slice.call(arguments, 1);
-  var advertise = this.options.advertise;
-  var separator = advertise ? ' ' : '.';
-  var customVars;
+function createLabels(prefix, pageMeta){
+  var pageMeta = joinLabels(pageMeta, '.');
+  var labels = joinLabels([prefix, pageMeta], '.');
+  var customLabels = arguments[2];
 
-  if (advertise && 'page' == type) type = 'event';
-  if (advertise) type = '_fp.' + type;
+  if (customLabels) {
+    customLabels = joinLabels(customLabels, ',');
+    labels = joinLabels([labels, customLabels], ',');
+  }
 
-  var ret = reduce(args, function(ret, arg){
-    if (is.object(arg) && arg.label) {
-      customVars = arg.label;
-    }
+  return labels.replace(/, /g, ',');
+};
 
-    if (arg != null && !is.object(arg)) {
-      ret.push(String(arg).replace(/, /g, ','));
-    }
-    return ret;
-  }, []).join(separator);
+/**
+ * Helper method to join labels together.
+ *
+ * @param {Array} lables
+ * @param {String} separator
+ * @return {String}
+ * @api private
+ */
 
-  var labels = [type, ret].join('.');
-  if (customVars) labels = [labels, customVars].join(',');
-
-  return labels;
+function joinLabels(labels, separator){
+  return labels.join(separator);
 };

--- a/lib/quantcast/test.js
+++ b/lib/quantcast/test.js
@@ -131,7 +131,7 @@ describe('Quantcast', function(){
         analytics.page('Category', 'Page', { label: 'TestLabel' });
         analytics.called(window._qevents.push, {
           event: 'refresh',
-          labels: 'page.Category.Page.TestLabel',
+          labels: 'page.Category.Page,TestLabel',
           qacct: options.pCode
         });
       });
@@ -213,7 +213,7 @@ describe('Quantcast', function(){
         analytics.track('event', { label: 'newLabel,OtherLables' });
         analytics.called(window._qevents.push, {
           event: 'click',
-          labels: 'event.event.newLabel,OtherLables',
+          labels: 'event.event,newLabel,OtherLables',
           qacct: options.pCode
         });
       });

--- a/lib/quantcast/test.js
+++ b/lib/quantcast/test.js
@@ -128,7 +128,7 @@ describe('Quantcast', function(){
       });
 
       it('should add the properties labels to the label string', function(){
-        analytics.page('Category', 'Page', { label: 'TestLabel' });
+        analytics.page('Category', 'Page', { property: true }, { integrations: { Quantcast: { labels: ['TestLabel'] }}});
         analytics.called(window._qevents.push, {
           event: 'refresh',
           labels: 'page.Category.Page,TestLabel',
@@ -163,7 +163,7 @@ describe('Quantcast', function(){
           analytics.page('Category Name', 'Page Name');
           analytics.called(window._qevents.push, {
             event: 'refresh',
-            labels: '_fp.event.Category Name Page Name',
+            labels: '_fp.event.Category Name.Page Name',
             qacct: options.pCode
           });
         });
@@ -210,7 +210,7 @@ describe('Quantcast', function(){
       });
 
       it('should push custom labels for the event', function(){
-        analytics.track('event', { label: 'newLabel,OtherLables' });
+        analytics.track('event', { property: true }, { integrations: { Quantcast: { labels: ['newLabel','OtherLables'] }}});
         analytics.called(window._qevents.push, {
           event: 'click',
           labels: 'event.event,newLabel,OtherLables',


### PR DESCRIPTION
I realised that the labels were not working quite as they should be - the first custom label that you passed was being treated as a child label of the page's category/name labels (labels separated by dots are parent/child labels). 

Now, It will put a comma between the 'inbuilt' labels that come from the page information, and the custom labels that you pass in - which is how quantcast is expecting to receive the labels. 

@ndhoule 
