### PR TITLE
Correctly respect createdAt as per our spec

### DIFF
--- a/integrations.js
+++ b/integrations.js
@@ -77,11 +77,11 @@ module.exports = [
   require('./lib/tapstream'),
   require('./lib/trakio'),
   require('./lib/twitter-ads'),
+  require('./lib/userlike'),
   require('./lib/uservoice'),
   require('./lib/vero'),
   require('./lib/visual-website-optimizer'),
   require('./lib/webengage'),
   require('./lib/woopra'),
-  require('./lib/yandex-metrica'),
-  require('./lib/userlike')
+  require('./lib/yandex-metrica')
 ];

--- a/lib/mixpanel/index.js
+++ b/lib/mixpanel/index.js
@@ -100,7 +100,7 @@ Mixpanel.prototype.page = function(page){
  */
 
 var traitAliases = {
-  created: '$created',
+  createdAt: '$created',
   email: '$email',
   firstName: '$first_name',
   lastName: '$last_name',
@@ -134,7 +134,6 @@ Mixpanel.prototype.identify = function(identify){
 
   // traits
   var traits = identify.traits(traitAliases);
-  if (traits.$created) del(traits, 'createdAt');
   window.mixpanel.register(dates(traits, iso));
   if (this.options.people) window.mixpanel.people.set(traits);
 };

--- a/lib/mixpanel/test.js
+++ b/lib/mixpanel/test.js
@@ -174,7 +174,7 @@ describe('Mixpanel', function(){
       it('should alias traits', function(){
         var date = new Date();
         analytics.identify({
-          created: date,
+          createdAt: date,
           email: 'name@example.com',
           firstName: 'first',
           lastName: 'last',
@@ -199,7 +199,7 @@ describe('Mixpanel', function(){
         mixpanel.options.people = true;
         var date = new Date();
         analytics.identify({
-          created: date,
+          createdAt: date,
           email: 'name@example.com',
           firstName: 'first',
           lastName: 'last',
@@ -219,31 +219,6 @@ describe('Mixpanel', function(){
           $phone: 'phone'
         });
       });
-
-      it('should remove .created_at', function(){
-        mixpanel.options.people = true;
-        var date = new Date();
-        analytics.identify({
-          created_at: date,
-          email: 'name@example.com',
-          firstName: 'first',
-          lastName: 'last',
-          lastSeen: date,
-          name: 'name',
-          username: 'username',
-          phone: 'phone'
-        });
-        analytics.called(window.mixpanel.people.set, {
-          $created: date,
-          $email: 'name@example.com',
-          $first_name: 'first',
-          $last_name: 'last',
-          $last_seen: date,
-          $name: 'name',
-          $username: 'username',
-          $phone: 'phone'
-        });
-      })
     });
 
     describe('#track', function(){


### PR DESCRIPTION
We were transforming `created` for Mixpanel, but from our spec, the parameter should be sent as `createdAt` in the first place.
