### PR TITLE
GA: Added event name and category for ecommerce

### DIFF
--- a/lib/google-analytics/index.js
+++ b/lib/google-analytics/index.js
@@ -538,7 +538,7 @@ GA.prototype.loadEnhancedEcommerce = function(track){
 GA.prototype.pushEnhancedEcommerce = function(track){
   // Send a custom non-interaction event to ensure all EE data is pushed.
   // Without doing this we'd need to require page display after setting EE data.
-  ga('send', 'event', 'EnhancedEcommerce', 'Push', { nonInteraction: 1 });
+  ga('send', 'event', track.category() || 'EnhancedEcommerce', track.event(), { nonInteraction: 1 });
 };
 
 /**
@@ -583,8 +583,8 @@ GA.prototype.viewedCheckoutStepEnhanced = function(track){
   this.loadEnhancedEcommerce(track);
 
   each(products, function(product){
-    var track = new Track({ properties: product });
-    enhancedEcommerceTrackProduct(track);
+    var trackTemp = new Track({ properties: product });
+    enhancedEcommerceTrackProduct(trackTemp);
   });
 
   window.ga('ec:setAction','checkout', {
@@ -592,7 +592,7 @@ GA.prototype.viewedCheckoutStepEnhanced = function(track){
     option: options || undefined,
   });
 
-  this.pushEnhancedEcommerce();
+  this.pushEnhancedEcommerce(track);
 };
 
 /**

--- a/lib/google-analytics/test.js
+++ b/lib/google-analytics/test.js
@@ -693,7 +693,7 @@ describe('Google Analytics', function(){
             variant: undefined,
           }]);
           analytics.deepEqual(window.ga.args[3], ['ec:setAction', 'add', {}]);
-          analytics.deepEqual(window.ga.args[4], ['send', 'event', 'EnhancedEcommerce', 'Push', { nonInteraction: 1 }]);
+          analytics.deepEqual(window.ga.args[4], ['send', 'event', 'cat 1', 'added product', { nonInteraction: 1 }]);
         });
 
         it('should send removed product data', function(){
@@ -718,7 +718,7 @@ describe('Google Analytics', function(){
             variant: undefined,
           }]);
           analytics.deepEqual(window.ga.args[3], ['ec:setAction', 'remove', {}]);
-          analytics.deepEqual(window.ga.args[4], ['send', 'event', 'EnhancedEcommerce', 'Push', { nonInteraction: 1 }]);
+          analytics.deepEqual(window.ga.args[4], ['send', 'event', 'cat 1', 'removed product', { nonInteraction: 1 }]);
         });
 
         it('should send viewed product details data', function(){
@@ -743,7 +743,7 @@ describe('Google Analytics', function(){
             variant: undefined,
           }]);
           analytics.deepEqual(window.ga.args[3], ['ec:setAction', 'detail', {}]);
-          analytics.deepEqual(window.ga.args[4], ['send', 'event', 'EnhancedEcommerce', 'Push', { nonInteraction: 1 }]);
+          analytics.deepEqual(window.ga.args[4], ['send', 'event', 'cat 1', 'viewed product details', { nonInteraction: 1 }]);
         });
 
         it('should send clicked product data', function(){
@@ -771,7 +771,7 @@ describe('Google Analytics', function(){
           analytics.deepEqual(window.ga.args[3], ['ec:setAction', 'click', {
             list: 'search results'
           }]);
-          analytics.deepEqual(window.ga.args[4], ['send', 'event', 'EnhancedEcommerce', 'Push', { nonInteraction: 1 }]);
+          analytics.deepEqual(window.ga.args[4], ['send', 'event', 'cat 1', 'clicked product', { nonInteraction: 1 }]);
         });
 
         it('should send viewed product data', function(){
@@ -795,7 +795,7 @@ describe('Google Analytics', function(){
             list: 'search results',
             position: 1
           }]);
-          analytics.deepEqual(window.ga.args[3], ['send', 'event', 'EnhancedEcommerce', 'Push', { nonInteraction: 1 }]);
+          analytics.deepEqual(window.ga.args[3], ['send', 'event', 'cat 1', 'viewed product', { nonInteraction: 1 }]);
         });
 
         it('should send viewed promotion data', function(){
@@ -815,7 +815,7 @@ describe('Google Analytics', function(){
             creative: 'summer_banner2',
             position: 'banner_slot1'
           }]);
-          analytics.deepEqual(window.ga.args[3], ['send', 'event', 'EnhancedEcommerce', 'Push', { nonInteraction: 1 }]);
+          analytics.deepEqual(window.ga.args[3], ['send', 'event', 'EnhancedEcommerce', 'viewed promotion', { nonInteraction: 1 }]);
         });
 
         it('should send clicked promotion data', function(){
@@ -836,7 +836,7 @@ describe('Google Analytics', function(){
             position: 'banner_slot1'
           }]);
           analytics.deepEqual(window.ga.args[3], ['ec:setAction', 'promo_click', {}]);
-          analytics.deepEqual(window.ga.args[4], ['send', 'event', 'EnhancedEcommerce', 'Push', { nonInteraction: 1 }]);
+          analytics.deepEqual(window.ga.args[4], ['send', 'event', 'EnhancedEcommerce', 'clicked promotion', { nonInteraction: 1 }]);
         });
 
         it('should send started order data', function(){
@@ -856,7 +856,6 @@ describe('Google Analytics', function(){
             step: 1,
             paymentMethod: 'Visa'
           });
-
           analytics.assert(6 == window.ga.args.length);
           analytics.deepEqual(window.ga.args[1], ['set', '&cu', 'CAD']);
           analytics.deepEqual(window.ga.args[2], ['ec:addProduct', {
@@ -881,7 +880,7 @@ describe('Google Analytics', function(){
             step: 1,
             option: 'Visa'
           }]);
-          analytics.deepEqual(window.ga.args[5], ['send', 'event', 'EnhancedEcommerce', 'Push', { nonInteraction: 1 }]);
+          analytics.deepEqual(window.ga.args[5], ['send', 'event', 'EnhancedEcommerce', 'started order', { nonInteraction: 1 }]);
         });
 
         it('should send updated order data', function(){
@@ -928,7 +927,7 @@ describe('Google Analytics', function(){
             step: 1,
             option: 'Visa'
           }]);
-          analytics.deepEqual(window.ga.args[5], ['send', 'event', 'EnhancedEcommerce', 'Push', { nonInteraction: 1 }]);
+          analytics.deepEqual(window.ga.args[5], ['send', 'event', 'EnhancedEcommerce', 'updated order', { nonInteraction: 1 }]);
         });
 
         it('should send viewed checkout step data', function(){
@@ -943,7 +942,7 @@ describe('Google Analytics', function(){
             step: 2,
             option: undefined,
           }]);
-          analytics.deepEqual(window.ga.args[3], ['send', 'event', 'EnhancedEcommerce', 'Push', { nonInteraction: 1 }]);
+          analytics.deepEqual(window.ga.args[3], ['send', 'event', 'EnhancedEcommerce', 'viewed checkout step', { nonInteraction: 1 }]);
         });
 
         it('should send completed checkout step data', function(){
@@ -1008,7 +1007,7 @@ describe('Google Analytics', function(){
             shipping: undefined,
             coupon: undefined
           }]);
-          analytics.deepEqual(window.ga.args[3], ['send', 'event', 'EnhancedEcommerce', 'Push', { nonInteraction: 1 }]);
+          analytics.deepEqual(window.ga.args[3], ['send', 'event', 'EnhancedEcommerce', 'completed order', { nonInteraction: 1 }]);
         });
 
         it('should send completed order data', function(){
@@ -1063,7 +1062,7 @@ describe('Google Analytics', function(){
             shipping: 13.99,
             coupon: 'coupon'
           }]);
-          analytics.deepEqual(window.ga.args[5], ['send', 'event', 'EnhancedEcommerce', 'Push', { nonInteraction: 1 }]);
+          analytics.deepEqual(window.ga.args[5], ['send', 'event', 'EnhancedEcommerce', 'completed order', { nonInteraction: 1 }]);
         });
 
         it('completed order should fallback to revenue', function(){
@@ -1092,7 +1091,7 @@ describe('Google Analytics', function(){
           analytics.deepEqual(window.ga.args[2], ['ec:setAction', 'refund', {
             id: '780bc55'
           }]);
-          analytics.deepEqual(window.ga.args[3], ['send', 'event', 'EnhancedEcommerce', 'Push', { nonInteraction: 1 }]);
+          analytics.deepEqual(window.ga.args[3], ['send', 'event', 'EnhancedEcommerce', 'refunded order', { nonInteraction: 1 }]);
         });
 
         it('should send partial refunded order data', function(){
@@ -1119,7 +1118,7 @@ describe('Google Analytics', function(){
           analytics.deepEqual(window.ga.args[4], ['ec:setAction', 'refund', {
             id: '780bc55'
           }]);
-          analytics.deepEqual(window.ga.args[5], ['send', 'event', 'EnhancedEcommerce', 'Push', { nonInteraction: 1 }]);
+          analytics.deepEqual(window.ga.args[5], ['send', 'event', 'EnhancedEcommerce', 'refunded order', { nonInteraction: 1 }]);
         });
       });
     });


### PR DESCRIPTION
This resolves this: 
https://github.com/segmentio/analytics.js-integrations/issues/508
raised by: 
https://segment.zendesk.com/agent/tickets/23190

Added the event name as the event action, as well as the event category if it exists as the event category, defaulting on 'EnhancedEcommerce'.

@sperand-io 
