### PR TITLE
Intercom: updating company format

### DIFF
--- a/component.json
+++ b/component.json
@@ -61,7 +61,8 @@
     "segmentio/json": "^1.0.0",
     "component/reduce": "1.0.1",
     "ianstormtaylor/pick": "~0.1.0",
-    "harrietgrace/omit": "~0.1.0"
+    "harrietgrace/omit": "~0.1.0",
+    "darkskyapp/string-hash": "*"
   },
   "development": {
     "component/jquery": "*",

--- a/lib/intercom/index.js
+++ b/lib/intercom/index.js
@@ -9,10 +9,12 @@ var defaults = require('defaults');
 var del = require('obj-case').del;
 var isEmail = require('is-email');
 var load = require('load-script');
+var hash = require('string-hash');
 var empty = require('is-empty');
 var alias = require('alias');
 var each = require('each');
 var when = require('when');
+var dot = require('obj-case');
 var is = require('is');
 
 /**
@@ -75,8 +77,6 @@ Intercom.prototype.identify = function(identify){
   var traits = identify.traits({ userId: 'user_id' });
   var activator = this.options.activator;
   var opts = identify.options(this.name);
-  var companyCreated = identify.companyCreated();
-  var created = identify.created();
   var email = identify.email();
   var name = identify.name();
   var id = identify.userId();
@@ -86,28 +86,30 @@ Intercom.prototype.identify = function(identify){
 
   traits.app_id = this.options.appId;
 
-  // intercom requires `company` to be an object. default it with group traits
-  // so that we guarantee an `id` is there, since they require it
-  if (null != traits.company && !is.object(traits.company)) delete traits.company;
-  if (traits.company) defaults(traits.company, group.traits());
-
   // name
   if (name) traits.name = name;
 
   // handle dates
-  if (created) {
+  if (identify.created()) {
     del(traits, 'created');
     del(traits, 'createdAt');
-    traits.created_at = created;
+    traits.signed_up_at = identify.created();
   }
-  if (companyCreated) {
+  if (identify.companyCreated()) {
     del(traits.company, 'created');
     del(traits.company, 'createdAt');
-    traits.company.created_at = companyCreated;
+    traits.company.created_at = identify.companyCreated();
   }
 
   // convert dates
   traits = convertDates(traits, formatDate);
+
+  var companies = dot(traits, 'companies');
+  var company = dot(traits, 'company');
+
+  if (is.object(company) || is.string(company)) traits.companies = formatCompany(company);
+
+  del(traits, 'company');
 
   // handle options
   if (opts.increments) traits.increments = opts.increments;
@@ -162,4 +164,38 @@ Intercom.prototype.track = function(track){
 
 function formatDate(date) {
   return Math.floor(date / 1000);
-}
+};
+
+/**
+ * Formats a company for use with intercom
+ *
+ * http://docs.intercom.io/#Companies
+ *
+ * TODO: add .companies()
+ *
+ * @param {Object} company
+ * @return {Object}
+ * @api private
+ */
+
+function formatCompany(company){
+  if (is.string(company)) return [{ name: company }];
+
+  var ret = {};
+  ret.name = company.name;
+  del(company, 'name');
+
+  if (company.id) {
+    ret.company_id = company.id;
+    del(company, 'id');
+  }
+
+  var created = dot(company, 'created_at');
+  if (created) ret.remote_created_at = created;
+  del(company, 'created');
+  del(company, 'created_at');
+
+  if (!is.empty(company)) ret.custom_attributes = company;
+
+  return [ret];
+};

--- a/lib/intercom/test.js
+++ b/lib/intercom/test.js
@@ -97,9 +97,9 @@ describe('Intercom', function(){
       });
 
       it('should send an id and traits', function(){
-        analytics.identify('id', { email: 'email@example.com' });
+        analytics.identify('id', { email: 'tony@starkindustries.com' });
         analytics.called(window.Intercom, 'boot', {
-          email: 'email@example.com',
+          email: 'tony@starkindustries.com',
           app_id: options.appId,
           user_id: 'id',
           id: 'id'
@@ -107,34 +107,34 @@ describe('Intercom', function(){
       });
 
       it('should send user name', function(){
-        analytics.identify('id', { name: 'john doe' });
+        analytics.identify('id', { name: 'Tony Stark' });
         analytics.called(window.Intercom, 'boot', {
           app_id: options.appId,
           user_id: 'id',
-          name: 'john doe',
+          name: 'Tony Stark',
           id: 'id'
         });
       });
 
       it('should send first and last as name', function(){
-        analytics.identify('id', { firstName: 'john', lastName: 'doe' });
+        analytics.identify('id', { firstName: 'Tony', lastName: 'Stark' });
         analytics.called(window.Intercom, 'boot', {
           app_id: options.appId,
           user_id: 'id',
-          firstName: 'john',
-          lastName: 'doe',
-          name: 'john doe',
+          firstName: 'Tony',
+          lastName: 'Stark',
+          name: 'Tony Stark',
           id: 'id'
         });
       });
 
       it('should respect .name, .firstName and .lastName', function(){
-        analytics.identify('id', { firstName: 'john', lastName: 'doe', name: 'baz' });
+        analytics.identify('id', { firstName: 'Tony', lastName: 'Stark', name: 'baz' });
         analytics.called(window.Intercom, 'boot', {
           app_id: options.appId,
           user_id: 'id',
-          firstName: 'john',
-          lastName: 'doe',
+          firstName: 'Tony',
+          lastName: 'Stark',
           name: 'baz',
           id: 'id'
         });
@@ -146,15 +146,15 @@ describe('Intercom', function(){
 
           analytics.identify('id', {
             created: date,
-            company: { created: date }
+            company: { name: 'Stark Industries', created: date }
           });
 
           analytics.called(window.Intercom, 'boot', {
+            id: 'id',
             app_id: options.appId,
             user_id: 'id',
-            created_at: Math.floor(date / 1000),
-            company: { created_at: Math.floor(date / 1000) },
-            id: 'id'
+            signed_up_at: Math.floor(date / 1000),
+            companies: [{ name: 'Stark Industries', remote_created_at: Math.floor(date / 1000) }]
           });
         });
 
@@ -165,14 +165,14 @@ describe('Intercom', function(){
 
           analytics.identify('12345', {
             createdAt: isoDate,
-            company: { created: isoDate }
+            company: { name: 'Stark Industries', created: isoDate }
           });
 
           analytics.called(window.Intercom, 'boot', {
             app_id: options.appId,
             user_id: '12345',
-            created_at: unixDate,
-            company: { created_at: unixDate },
+            signed_up_at: unixDate,
+            companies: [{ name: 'Stark Industries', remote_created_at: unixDate }],
             id: '12345'
           });
         });
@@ -182,14 +182,14 @@ describe('Intercom', function(){
 
           analytics.identify('12345', {
             createdAt: date,
-            company: { created: date }
+            company: { name: 'Stark Industries', created: date }
           });
 
           analytics.called(window.Intercom, 'boot', {
             app_id: options.appId,
             user_id: '12345',
-            created_at: date,
-            company: { created_at: date },
+            signed_up_at: date,
+            companies: [{ name: 'Stark Industries', remote_created_at: date }],
             id: '12345'
           });
         });
@@ -199,14 +199,14 @@ describe('Intercom', function(){
 
           analytics.identify('12345', {
             createdAt: date,
-            company: { created: date }
+            company: { name: 'Stark Industries', created: date }
           });
 
           analytics.called(window.Intercom, 'boot', {
             app_id: options.appId,
             user_id: '12345',
-            created_at: Math.floor(date / 1000),
-            company: { created_at: Math.floor(date / 1000) },
+            signed_up_at: Math.floor(date / 1000),
+            companies: [{ name: 'Stark Industries', remote_created_at: Math.floor(date / 1000) }],
             id: '12345'
           });
         });
@@ -259,11 +259,22 @@ describe('Intercom', function(){
       });
 
       it('should not fail when the company trait is a string', function(){
-        analytics.identify('id', { company: 'string' });
+        analytics.identify('id', { company: 'Stark Industries' });
         analytics.called(window.Intercom, 'boot', {
           app_id: options.appId,
           user_id: 'id',
-          id: 'id'
+          id: 'id',
+          companies: [{ name: 'Stark Industries' }]
+        });
+      });
+
+      it('should set company id and not generate a new one', function(){
+        analytics.identify('id', { company: { name: 'Stark Industries', id: 4017389226 } });
+        analytics.called(window.Intercom, 'boot', {
+          app_id: options.appId,
+          user_id: 'id',
+          id: 'id',
+          companies: [{ name: 'Stark Industries', company_id: 4017389226 }]
         });
       });
 
@@ -273,20 +284,6 @@ describe('Intercom', function(){
           app_id: options.appId,
           user_id: 'id',
           id: 'id'
-        });
-      });
-
-      it('should carry over company traits set in group if a company trait exists', function(){
-        analytics.group().traits({ foo: 'bar' });
-        analytics.identify('id', { company: { name: 'name' }});
-        analytics.called(window.Intercom, 'boot', {
-          app_id: options.appId,
-          user_id: 'id',
-          id: 'id',
-          company: {
-            name: 'name',
-            foo: 'bar'
-          }
         });
       });
     });


### PR DESCRIPTION
Changing company support in .identify() to match what Intercom accepts (and what we have server side):

```
companies: [
  {
    //company info
  }
]
```

Also changed the date key names to match Intercom's api - `created_at` is the time the user was added to Intercom, so we're using `signed_up_at` instead, which is the time the user signed up. For companies, they have a similar convention - `created_at` is the time the user was added to Intercom, and we're using `remote_created_at`, which is the time we sent the data.

@ndhoule 
