### PR TITLE
Sentry: Attempt to use existing RavenConfig global.

### DIFF
--- a/lib/sentry/index.js
+++ b/lib/sentry/index.js
@@ -23,8 +23,9 @@ var Sentry = module.exports = integration('Sentry')
  */
 
 Sentry.prototype.initialize = function(){
-  var dsn = this.options.config;
-  window.RavenConfig = { dsn: dsn };
+  var config = window.RavenConfig || (window.RavenConfig = {});
+  config.dsn = this.options.config;
+
   this.load(this.ready);
 };
 

--- a/lib/sentry/test.js
+++ b/lib/sentry/test.js
@@ -45,6 +45,16 @@ describe('Sentry', function(){
         analytics.page();
         analytics.called(sentry.load);
       });
+
+      it('should use existing RavenConfig global', function(){
+        window.RavenConfig = {
+          foo: 'foo'
+        };
+
+        analytics.initialize();
+        analytics.assert(window.RavenConfig.foo === 'foo');
+        analytics.assert(window.RavenConfig.dsn === options.config);
+      });
     });
   });
 


### PR DESCRIPTION
Attempts to reuse the existing `window.RavenConfig` object before setting the `dsn` property to `options.config`.

This allows developers to extend the configuration to include such things as version tags, whitelists etc.
