### PR TITLE
Drip: updated to new global

### DIFF
--- a/lib/drip/index.js
+++ b/lib/drip/index.js
@@ -15,7 +15,7 @@ var push = require('global-queue')('_dcq');
 
 var Drip = module.exports = integration('Drip')
   .assumesPageview()
-  .global('dc')
+  .global('_dc')
   .global('_dcq')
   .global('_dcs')
   .option('account', '')
@@ -41,7 +41,7 @@ Drip.prototype.initialize = function(page){
  */
 
 Drip.prototype.loaded = function(){
-  return is.object(window.dc);
+  return is.object(window._dc);
 };
 
 /**

--- a/lib/drip/index.js
+++ b/lib/drip/index.js
@@ -16,6 +16,7 @@ var push = require('global-queue')('_dcq');
 var Drip = module.exports = integration('Drip')
   .assumesPageview()
   .global('_dc')
+  .global('_dcqi')
   .global('_dcq')
   .global('_dcs')
   .option('account', '')

--- a/lib/drip/test.js
+++ b/lib/drip/test.js
@@ -10,7 +10,7 @@ describe('Drip', function(){
   var drip;
   var analytics;
   var options = {
-    account: '9999999'
+    account: '3826504'
   };
 
   beforeEach(function(){
@@ -31,7 +31,7 @@ describe('Drip', function(){
   it('should have the right settings', function(){
     analytics.compare(Drip, integration('Drip')
       .assumesPageview()
-      .global('dc')
+      .global('_dc')
       .global('_dcq')
       .global('_dcs')
       .option('account', ''));

--- a/lib/drip/test.js
+++ b/lib/drip/test.js
@@ -32,6 +32,7 @@ describe('Drip', function(){
     analytics.compare(Drip, integration('Drip')
       .assumesPageview()
       .global('_dc')
+      .global('_dcqi')
       .global('_dcq')
       .global('_dcs')
       .option('account', ''));


### PR DESCRIPTION
Drip seems to be using `_dc` instead of just `dc` as their global object now. They haven't updated their docs, but this is what their js lib looks like: https://cloudup.com/cmK9iXoV_IW

Was failing on load because we were trying to look at the old way of doing it. Also added in our test account's actual id for testing.

@ndhoule 
