### PR TITLE
Customer.io: remove assumes pageview

### DIFF
--- a/lib/customerio/index.js
+++ b/lib/customerio/index.js
@@ -13,7 +13,6 @@ var integration = require('analytics.js-integration');
  */
 
 var Customerio = module.exports = integration('Customer.io')
-  .assumesPageview()
   .global('_cio')
   .option('siteId', '')
   .tag('<script id="cio-tracker" src="https://assets.customer.io/assets/track.js" data-site-id="{{ siteId }}">');

--- a/lib/customerio/test.js
+++ b/lib/customerio/test.js
@@ -30,7 +30,6 @@ describe('Customer.io', function(){
 
   it('should have the right settings', function(){
     analytics.compare(Customerio, integration('Customer.io')
-      .assumesPageview()
       .global('_cio')
       .option('siteId', ''));
   });
@@ -44,13 +43,11 @@ describe('Customer.io', function(){
       it('should create the window._cio object', function(){
         analytics.assert(!window._cio);
         analytics.initialize();
-        analytics.page();
         analytics.assert(window._cio);
       });
 
       it('should call #load', function(){
         analytics.initialize();
-        analytics.page();
         analytics.called(customerio.load);
       });
     });
@@ -66,7 +63,6 @@ describe('Customer.io', function(){
     beforeEach(function(done){
       analytics.once('ready', done);
       analytics.initialize();
-      analytics.page();
     });
 
     describe('#identify', function(){


### PR DESCRIPTION
We don't need assumesPageview on integrations that don't map page.

This is only to guard against duplicates in scenarios where the integrated library has a deliberate page method which we map _but also calls that method itself on load_. Not the case here.
