### PR TITLE
Update Amplitude to v2.0.3

### DIFF
--- a/lib/amplitude/index.js
+++ b/lib/amplitude/index.js
@@ -17,7 +17,7 @@ var umd = 'function' == typeof define && define.amd;
  * Source.
  */
 
-var src = '//d24n15hnbwhuhn.cloudfront.net/libs/amplitude-2.0.2-min.js';
+var src = '//d24n15hnbwhuhn.cloudfront.net/libs/amplitude-2.0.3-min.js';
 
 /**
  * Expose `Amplitude` integration.


### PR DESCRIPTION
Updating to release v2.0.3 for Amplitude (https://github.com/amplitude/Amplitude-Javascript/releases/tag/v2.0.3)
