### PR TITLE
Update Heap integration to new snippet.

### DIFF
--- a/lib/heap/index.js
+++ b/lib/heap/index.js
@@ -24,7 +24,23 @@ var Heap = module.exports = integration('Heap')
  */
 
 Heap.prototype.initialize = function(page){
-  window.heap=window.heap||[],window.heap.load=function(t,e){window.heap.appid=t,window.heap.config=e;for (var o=function(t){return function(){heap.push([t].concat(Array.prototype.slice.call(arguments,0)))}},p=["clearEventProperties","identify","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
+  window.heap = window.heap || [];
+  window.heap.load = function(appid, config){
+    window.heap.appid = appid;
+    window.heap.config = config;
+
+    var methodFactory = function(type){
+      return function(){
+        heap.push([type].concat(Array.prototype.slice.call(arguments, 0)));
+      };
+    };
+
+    var methods = ['clearEventProperties', 'identify', 'setEventProperties', 'track', 'unsetEventProperty'];
+    for (var i = 0; i < methods.length; i++) {
+      heap[methods[i]] = methodFactory(methods[i]);
+    }
+  };
+
   window.heap.load(this.options.appId);
   this.load(this.ready);
 };

--- a/lib/heap/index.js
+++ b/lib/heap/index.js
@@ -12,20 +12,19 @@ var alias = require('alias');
 
 var Heap = module.exports = integration('Heap')
   .global('heap')
-  .global('_heapid')
   .option('appId', '')
-  .tag('<script src="//d36lvucg9kzous.cloudfront.net">');
+  .tag('<script src="//cdn.heapanalytics.com/js/heap-{{ appId }}.js">');
 
 /**
  * Initialize.
  *
- * https://heapanalytics.com/docs#installWeb
+ * https://heapanalytics.com/docs/installation#web
  *
  * @param {Object} page
  */
 
 Heap.prototype.initialize = function(page){
-  window.heap=window.heap||[];window.heap.load=function(a){window._heapid=a;var d=function(a){return function(){window.heap.push([a].concat(Array.prototype.slice.call(arguments,0)));};},e=["identify","track"];for (var f=0;f<e.length;f++)window.heap[e[f]]=d(e[f]);};
+  window.heap=window.heap||[],window.heap.load=function(t,e){window.heap.appid=t,window.heap.config=e;for (var o=function(t){return function(){heap.push([t].concat(Array.prototype.slice.call(arguments,0)))}},p=["clearEventProperties","identify","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
   window.heap.load(this.options.appId);
   this.load(this.ready);
 };

--- a/lib/heap/test.js
+++ b/lib/heap/test.js
@@ -11,7 +11,7 @@ describe('Heap', function(){
   var heap;
   var analytics;
   var options = {
-    appId: 'x'
+    appId: '1535634150'
   };
 
   beforeEach(function(){
@@ -32,7 +32,6 @@ describe('Heap', function(){
   it('should have the right settings', function(){
     analytics.compare(Heap, integration('Heap')
       .global('heap')
-      .global('_heapid')
       .option('appId', ''));
   });
 
@@ -49,7 +48,7 @@ describe('Heap', function(){
       });
 
       it('should stub window.heap with the right methods', function(){
-        var methods = ['identify', 'track'];
+        var methods = ['clearEventProperties', 'identify', 'setEventProperties', 'track', 'unsetEventProperty'];
         analytics.assert(!window.heap);
         analytics.initialize();
         each(methods, function(method){
@@ -57,10 +56,10 @@ describe('Heap', function(){
         });
       });
 
-      it('should set window._heapid', function(){
-        analytics.assert(!window._heapid);
+      it('should set window.heap.appid', function(){
+        analytics.assert(!window.heap);
         analytics.initialize();
-        analytics.assert(window._heapid === options.appId);
+        analytics.assert(window.heap.appid === options.appId);
       });
 
       it('should call #load', function(){


### PR DESCRIPTION
This upgrades the Heap snippet to the latest version.

Other minor changes:
- Verify existence of new methods on the Heap stub object (`setEventProperties`, etc).
- Verify that Heap was loaded properly via `window.heap.appid`, not `window._heapid`.
- Fixed broken link to Heap installation steps.
