### PR TITLE
allow the user to force display of the Intercom default widget

### DIFF
--- a/lib/intercom/index.js
+++ b/lib/intercom/index.js
@@ -122,6 +122,13 @@ Intercom.prototype.identify = function(identify){
     traits.widget = { activator: activator };
   }
 
+  // Let the user override the widget selector
+  // from javascript.  This provides a mechanism
+  // to force display of the default widget even
+  // if the Intercom admin console isn't configured
+  // to always display the widget
+  if (opts.widget) traits.widget = opts.widget;
+
   var method = this._id !== id ? 'boot': 'update';
   this._id = id; // cache for next time
 

--- a/lib/intercom/test.js
+++ b/lib/intercom/test.js
@@ -289,6 +289,19 @@ describe('Intercom', function(){
           }
         });
       });
+
+      it('should allow the user to override the widget setting', function(){
+        analytics.identify('id', { intercomOptions: { widget: { activator: '#my-custom-activator' } } });
+        analytics.called(window.Intercom, 'boot', {
+          app_id: options.appId,
+          user_id: 'id',
+          firstName: 'john',
+          lastName: 'doe',
+          name: 'baz',
+          id: 'id',
+          widget: { activator: '#my-custom-activator' }
+        });
+      });
     });
 
     describe('#group', function(){


### PR DESCRIPTION
This allow the user to force display of the Intercom default widget when it isn't configured to always be enabled.  I wasn't able to get my runtime environment to work so I'm counting on CI to verify my tests.
