### PR TITLE
GA Enhanced Ecommerce: Remove product impressions, fix viewed product

### DIFF
--- a/lib/google-analytics/index.js
+++ b/lib/google-analytics/index.js
@@ -81,7 +81,6 @@ GA.on('construct', function(integration){
   } else if (integration.options.enhancedEcommerce) {
     integration.viewedProduct = integration.viewedProductEnhanced;
     integration.clickedProduct = integration.clickedProductEnhanced;
-    integration.viewedProductDetails = integration.viewedProductDetailsEnhanced;
     integration.addedProduct = integration.addedProductEnhanced;
     integration.removedProduct = integration.removedProductEnhanced;
     integration.startedOrder = integration.startedOrderEnhanced;
@@ -725,33 +724,9 @@ GA.prototype.removedProductEnhanced = function(track){
  * @param {Track} track
  */
 
-GA.prototype.viewedProductDetailsEnhanced = function(track){
+GA.prototype.viewedProductEnhanced = function(track){
   this.loadEnhancedEcommerce(track);
   enhancedEcommerceProductAction(track, 'detail');
-  this.pushEnhancedEcommerce(track);
-};
-
-/**
- * Viewed product - Enhanced Ecommerce
- *
- * https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#measuring-impressions
- *
- * @param {Track} track
- */
-
-GA.prototype.viewedProductEnhanced = function(track){
-  var props = track.properties();
-
-  this.loadEnhancedEcommerce(track);
-  ga('ec:addImpression', {
-    id: track.id() || track.sku(),
-    name: track.name(),
-    category: track.category(),
-    brand: props.brand,
-    variant: props.variant,
-    list: props.list,
-    position: props.position,
-  });
   this.pushEnhancedEcommerce(track);
 };
 

--- a/lib/google-analytics/test.js
+++ b/lib/google-analytics/test.js
@@ -721,8 +721,8 @@ describe('Google Analytics', function(){
           analytics.deepEqual(window.ga.args[4], ['send', 'event', 'cat 1', 'removed product', { nonInteraction: 1 }]);
         });
 
-        it('should send viewed product details data', function(){
-          analytics.track('viewed product details', {
+        it('should send viewed product data', function(){
+          analytics.track('viewed product', {
             currency: 'CAD',
             quantity: 1,
             price: 24.75,
@@ -743,7 +743,7 @@ describe('Google Analytics', function(){
             variant: undefined,
           }]);
           analytics.deepEqual(window.ga.args[3], ['ec:setAction', 'detail', {}]);
-          analytics.deepEqual(window.ga.args[4], ['send', 'event', 'cat 1', 'viewed product details', { nonInteraction: 1 }]);
+          analytics.deepEqual(window.ga.args[4], ['send', 'event', 'cat 1', 'viewed product', { nonInteraction: 1 }]);
         });
 
         it('should send clicked product data', function(){
@@ -772,30 +772,6 @@ describe('Google Analytics', function(){
             list: 'search results'
           }]);
           analytics.deepEqual(window.ga.args[4], ['send', 'event', 'cat 1', 'clicked product', { nonInteraction: 1 }]);
-        });
-
-        it('should send viewed product data', function(){
-          analytics.track('viewed product', {
-            currency: 'CAD',
-            name: 'my product',
-            category: 'cat 1',
-            sku: 'p-298',
-            list: 'search results',
-            position: 1
-          });
-
-          analytics.assert(4 == window.ga.args.length);
-          analytics.deepEqual(window.ga.args[1], ['set', '&cu', 'CAD']);
-          analytics.deepEqual(window.ga.args[2], ['ec:addImpression', {
-            id: 'p-298',
-            name: 'my product',
-            category: 'cat 1',
-            brand: undefined,
-            variant: undefined,
-            list: 'search results',
-            position: 1
-          }]);
-          analytics.deepEqual(window.ga.args[3], ['send', 'event', 'cat 1', 'viewed product', { nonInteraction: 1 }]);
         });
 
         it('should send viewed promotion data', function(){


### PR DESCRIPTION
Fixes #505 

We were mis-mapping "Viewed Product" to GA's product "impression" (which is meant for seeing a product in a list, not the product's detail view) and required "Viewed Product Detail" for detail page views, which is not in accordance with our ecommerce API.

This PR maps "Viewed Product" to the detail view, in line with our API, and removes the impression call from our integration entirely.

Spoke with @DirtyAnalytics and we thought that product impressions are better sent to GA directly rather than via Segment. Here's why:
- No other tools make use of them.
- It's not uncommon for there to be as many as 50 products on a page. With 50 discrete "Product Impression" calls, that's 50 outbound HTTP requests to Segment from the page, even if the GA mapping were to take advantage of batching under the hood 

_but_ It may make sense for us to add a "Viewed Product List" event that takes an array of products and calls the impression event straight to GA for each, but would only fire a single HTTP request to GA to flush them and a single one to Segment. Would love to hear thoughts on that!

@amillet89 @f2prateek @ndhoule 
