### PR TITLE
Heap: alias email to _email instead of dropping it entirely

### DIFF
--- a/lib/heap/index.js
+++ b/lib/heap/index.js
@@ -64,9 +64,8 @@ Heap.prototype.loaded = function(){
  */
 
 Heap.prototype.identify = function(identify){
-  var traits = identify.traits();
+  var traits = identify.traits({ email: '_email' });
   var id = identify.userId();
-  if (traits.email) delete traits.email
   if (id) traits.handle = id;
   window.heap.identify(traits);
 };

--- a/lib/heap/test.js
+++ b/lib/heap/test.js
@@ -92,9 +92,9 @@ describe('Heap', function(){
         analytics.called(window.heap.identify, { trait: true });
       });
 
-      it('should not send email', function(){
+      it('should alias email to _email', function(){
         analytics.identify({ trait: true, email: 'email@email.org' });
-        analytics.called(window.heap.identify, { trait: true });
+        analytics.called(window.heap.identify, { trait: true, _email: 'email@email.org' });
       });
 
       it('should send id as handle', function(){


### PR DESCRIPTION
From my initial discussion with Ravi @ Heap, I was under the impression that `email` was not used for anything as long as we used `handle` instead. But as he mentioned in a follow up email:

> Would it be possible to instead just re-map it to some other key name? E.g. "Email Address" or something? Users may still want to see it show up in our dashboard.

This fixes that. 

Corresponding server-side fix here: https://github.com/segmentio/integration-heap/pull/2
