### PR TITLE
remove protocol from url so it loads on both `http` and `https`

### DIFF
--- a/lib/nudgespot/index.js
+++ b/lib/nudgespot/index.js
@@ -19,7 +19,7 @@ var Nudgespot = module.exports = integration('Nudgespot')
   .assumesPageview()
   .option('apiKey', '')
   .global('nudgespot')
-  .tag('<script id="nudgespot" src="http://cdn.nudgespot.com/nudgespot.js">');
+  .tag('<script id="nudgespot" src="//cdn.nudgespot.com/nudgespot.js">');
 
 /**
  * Initialize Nudgespot.


### PR DESCRIPTION
the nudgespot integration is currently not loading on `https` pages because it was trying to load from `http`.

This PR removes the protocol from the url so that it loads on both `http` and `https`
