### PR TITLE
added page() as a proxy to track() call in facebook conversions

### DIFF
--- a/lib/facebook-conversion-tracking/index.js
+++ b/lib/facebook-conversion-tracking/index.js
@@ -48,6 +48,17 @@ Facebook.prototype.loaded = function(){
 };
 
 /**
+ * Page.
+ *
+ * @param {Page} page
+ */
+
+Facebook.prototype.page = function(page){
+  var name = page.fullName();
+  this.track(page.track(name));
+}
+
+/**
  * Track.
  *
  * https://developers.facebook.com/docs/reference/ads-api/custom-audience-website-faq/#fbpixel

--- a/lib/facebook-conversion-tracking/test.js
+++ b/lib/facebook-conversion-tracking/test.js
@@ -51,6 +51,48 @@ describe('Facebook Conversion Tracking', function(){
       analytics.page();
     });
 
+    describe('#page', function(){
+      beforeEach(function(){
+        analytics.stub(window._fbq, 'push');
+      });
+
+      it('should track page view with fullname', function(){
+        analytics.page('Category', 'Name', { url: 'http://localhost:34448/test/' });
+        analytics.called(window._fbq.push, ['track', 'Viewed Category Name Page', {
+          url: 'http://localhost:34448/test/',
+          path: '/test/',
+          referrer: '',
+          title: 'integrations tests',
+          search: '',
+          name: 'Name',
+          category: 'Category'
+        }]);
+      });
+
+      it('should track unnamed/categorized page', function(){
+        analytics.page({ url: 'http://localhost:34448/test/' });
+        analytics.called(window._fbq.push, ['track', 'Loaded a Page', {
+          url: 'http://localhost:34448/test/',
+          path: '/test/',
+          referrer: '',
+          title: 'integrations tests',
+          search: ''
+        }]);
+      });
+
+      it('should track unnamed page', function(){
+        analytics.page('Name', { url: 'http://localhost:34448/test/' });
+        analytics.called(window._fbq.push, ['track', 'Viewed Name Page', {
+          url: 'http://localhost:34448/test/',
+          path: '/test/',
+          referrer: '',
+          title: 'integrations tests',
+          search: '',
+          name: 'Name'
+        }]);
+      });
+    });
+
     describe('#track', function(){
       beforeEach(function(){
         analytics.stub(window._fbq, 'push');


### PR DESCRIPTION
Now users can put "Viewed [Category] [Name] Page" in the Facebook options and then the `.page()` call trigger the pixel.

Added tests, as well.
