### PR TITLE
added option for cross subdomain cookie

### DIFF
--- a/lib/mixpanel/index.js
+++ b/lib/mixpanel/index.js
@@ -21,6 +21,7 @@ var Mixpanel = module.exports = integration('Mixpanel')
   .global('mixpanel')
   .option('increments', [])
   .option('cookieName', '')
+  .option('crossSubdomainCookie', false)
   .option('nameTag', true)
   .option('pageview', false)
   .option('people', false)
@@ -35,7 +36,8 @@ var Mixpanel = module.exports = integration('Mixpanel')
  */
 
 var optionsAliases = {
-  cookieName: 'cookie_name'
+  cookieName: 'cookie_name',
+  crossSubdomainCookie: 'cross_subdomain_cookie'
 };
 
 /**

--- a/lib/mixpanel/test.js
+++ b/lib/mixpanel/test.js
@@ -11,7 +11,9 @@ describe('Mixpanel', function(){
   var mixpanel;
   var analytics;
   var options = {
-    token: 'x'
+    token: 'x',
+    cookieName: 'y',
+    crossSubdomainCookie: true
   };
 
   beforeEach(function(){
@@ -32,7 +34,8 @@ describe('Mixpanel', function(){
   it('should have the right settings', function(){
     analytics.compare(Mixpanel, integration('Mixpanel')
       .global('mixpanel')
-      .option('cookieName', '')
+      .option('token', '')
+      .option('crossSubdomainCookie', false)
       .option('nameTag', true)
       .option('pageview', false)
       .option('people', false)


### PR DESCRIPTION
/cc @f2prateek @amillet89 

This adds an option for Mixpanel's `cross_subdomain_cookie`, which will fix the Heroku issues. Here's a [link](https://mixpanel.com/help/questions/articles/mixpanel-and-herokuappcom-subdomains-and-other-common-top-level-domains) to Mixpanel's documentation on this. We'll need to add it to the metadata as well.
