### PR TITLE
Google Analytics: add custom dimension/metric support to #page

### DIFF
--- a/lib/google-analytics/index.js
+++ b/lib/google-analytics/index.js
@@ -162,6 +162,7 @@ GA.prototype.page = function(page){
   var category = page.category();
   var props = page.properties();
   var name = page.fullName();
+  var opts = this.options;
   var campaign = page.proxy('context.campaign') || {};
   var pageview = {};
   var track;
@@ -177,6 +178,10 @@ GA.prototype.page = function(page){
   if (campaign.medium) pageview.campaignMedium = campaign.medium;
   if (campaign.content) pageview.campaignContent = campaign.content;
   if (campaign.term) pageview.campaignKeyword = campaign.term;
+
+  // custom dimensions and metrics
+  var custom = metrics(props, opts);
+  if (length(custom)) window.ga('set', custom);
 
   // send
   window.ga('send', 'pageview', pageview);

--- a/lib/google-analytics/test.js
+++ b/lib/google-analytics/test.js
@@ -256,6 +256,18 @@ describe('Google Analytics', function(){
           });
         });
 
+        it('should map custom dimensions & metrics using track.properties()', function(){
+          ga.options.metrics = { score: 'metric1' };
+          ga.options.dimensions = { author: 'dimension1', postType:'dimension2' };
+          analytics.page({ score: 21, author: 'Author', postType:'blog' });
+
+          analytics.called(window.ga, 'set', {
+            metric1: 21,
+            dimension1: 'Author',
+            dimension2: 'blog'
+          });
+        });
+
         it('should track a named page', function(){
           analytics.page('Name');
           analytics.called(window.ga, 'send', 'event', {


### PR DESCRIPTION
@amillet89 @ndhoule 

since we're now supporting hit-scoped via #track, i dont see why not for custom page properties! this was brought to our attention by a request from XO group
