### PR TITLE
AdRoll: send revenue with _all_ events, not just mapped ones

### DIFF
--- a/lib/adroll/index.js
+++ b/lib/adroll/index.js
@@ -93,6 +93,7 @@ AdRoll.prototype.track = function(track){
   if (orderId) data.order_id = orderId;
   if (productId) data.product_id = productId;
   if (sku) data.sku = sku;
+  if (total) data.adroll_conversion_value_in_dollars = total;
   del(customProps, "revenue");
   del(customProps, "total");
   del(customProps, "orderId");
@@ -101,7 +102,6 @@ AdRoll.prototype.track = function(track){
   if (!is.empty(customProps)) data.adroll_custom_data = customProps;
 
   each(events, function(event){
-    data.adroll_conversion_value_in_dollars = total;
     // the adroll interface only allows for
     // segment names which are snake cased.
     data.adroll_segments = snake(event);

--- a/lib/adroll/test.js
+++ b/lib/adroll/test.js
@@ -183,10 +183,12 @@ describe('AdRoll', function(){
           });
         });
 
-        it('should send events without revenue and order id', function(){
-          analytics.track('event', { revenue: 3.99 });
+        it('should send events with revenue and order id', function(){
+          analytics.track('event', { revenue: 3.99, order_id: 1 });
           analytics.called(window.__adroll.record_user, {
-            adroll_segments: 'event'
+            adroll_segments: 'event',
+            adroll_conversion_value_in_dollars: 3.99,
+            order_id: 1
           });
         });
 
@@ -195,6 +197,7 @@ describe('AdRoll', function(){
           analytics.track('event', { revenue: 3.99 });
           analytics.called(window.__adroll.record_user, {
             adroll_segments: 'event',
+            adroll_conversion_value_in_dollars: 3.99,
             user_id: 'id'
           });
         });


### PR DESCRIPTION
We send all events to AdRoll, not just mapped ones. The only reason we allow mapping is so that people can send multiple events to the same segment. I don't see any reason why we wouldnt send revenue in the non-mapped events, nor is that distinction made in our docs! @amillet89 @f2prateek @ndhoule 
