### PR TITLE
facebook: remove custom audience events from conversion tracking

### DIFF
--- a/lib/facebook-conversion-tracking/index.js
+++ b/lib/facebook-conversion-tracking/index.js
@@ -67,9 +67,4 @@ Facebook.prototype.track = function(track){
       currency: self.options.currency
     });
   });
-
-  if (!events.length) {
-    var data = track.properties();
-    push('track', event, data);
-  }
 };

--- a/lib/facebook-conversion-tracking/test.js
+++ b/lib/facebook-conversion-tracking/test.js
@@ -56,11 +56,6 @@ describe('Facebook Conversion Tracking', function(){
         analytics.stub(window._fbq, 'push');
       });
 
-      it('should send custom event even if event is not defined', function(){
-        analytics.track('event', { x: 10 });
-        analytics.called(window._fbq.push, ['track', 'event', { x: 10 }]);
-      });
-
       it('should send event if found', function(){
         analytics.track('signup', {});
         analytics.called(window._fbq.push, ['track', 0, {


### PR DESCRIPTION
this is a feature **[strictly for custom audiences](https://developers.facebook.com/docs/ads-for-websites/website-custom-audiences/planning#custom-data)** and causes duplicate events when users enable both (since the same call is being triggered [here](https://github.com/segmentio/analytics.js-integrations-private/blob/master/lib/facebook-custom-audiences/index.js#L66))

@amillet89 @f2prateek 
