### PR TITLE
Protect against a bad optimizely.data object

### DIFF
--- a/lib/optimizely/index.js
+++ b/lib/optimizely/index.js
@@ -83,7 +83,7 @@ Optimizely.prototype.replay = function(){
   if (!window.optimizely) return; // in case the snippet isnt on the page
 
   var data = window.optimizely.data;
-  if (!data) return;
+  if (!data || !data.experiments || !data.state) return;
 
   var experiments = data.experiments;
   var map = data.state.variationNamesMap;


### PR DESCRIPTION
We've seen cases where in IE7 the optimizely object is loaded with data set to empty hash (`{}`), which passes the original `if(!data)` null check, but throws a JS error when `data.state.variationsNamesMap` is read. This change protects against this case. Optimizely no longer supports IE7 or below after October 15th, 2014 (https://community.optimizely.com/t5/Product-What-s-New/Announcement-Starting-October-15th-2014-we-will-no-longer/ba-p/5164).

This is for issue #549.
