### PR TITLE
Send currency from track or product

### DIFF
--- a/lib/google-analytics/index.js
+++ b/lib/google-analytics/index.js
@@ -293,15 +293,15 @@ GA.prototype.completedOrder = function(track){
 
   // add products
   each(products, function(product){
-    var track = new Track({ properties: product });
+    var productTrack = createProductTrack(track, product);
     window.ga('ecommerce:addItem', {
-      category: track.category(),
-      quantity: track.quantity(),
-      price: track.price(),
-      name: track.name(),
-      sku: track.sku(),
+      category: productTrack.category(),
+      quantity: productTrack.quantity(),
+      price: productTrack.price(),
+      name: productTrack.name(),
+      sku: productTrack.sku(),
       id: orderId,
-      currency: track.currency()
+      currency: productTrack.currency()
     });
   });
 
@@ -587,13 +587,13 @@ GA.prototype.viewedCheckoutStepEnhanced = function(track){
   this.loadEnhancedEcommerce(track);
 
   each(products, function(product){
-    var trackTemp = new Track({ properties: product });
-    enhancedEcommerceTrackProduct(trackTemp);
+    var productTrack = createProductTrack(track, product);
+    enhancedEcommerceTrackProduct(productTrack);
   });
 
   window.ga('ec:setAction','checkout', {
     step: props.step || 1,
-    option: options || undefined,
+    option: options || undefined
   });
 
   this.pushEnhancedEcommerce(track);
@@ -618,7 +618,7 @@ GA.prototype.completedCheckoutStepEnhanced = function(track){
 
   window.ga('ec:setAction', 'checkout_option', {
     step: props.step || 1,
-    option: options,
+    option: options
   });
 
   window.ga('send', 'event', 'Checkout', 'Option');
@@ -644,8 +644,8 @@ GA.prototype.completedOrderEnhanced = function(track){
   this.loadEnhancedEcommerce(track);
 
   each(products, function(product){
-    var track = new Track({ properties: product });
-    enhancedEcommerceTrackProduct(track);
+    var productTrack = createProductTrack(track, product);
+    enhancedEcommerceTrackProduct(productTrack);
   });
 
   window.ga('ec:setAction', 'purchase', {
@@ -654,7 +654,7 @@ GA.prototype.completedOrderEnhanced = function(track){
     revenue: total,
     tax: track.tax(),
     shipping: track.shipping(),
-    coupon: track.coupon(),
+    coupon: track.coupon()
   });
 
   this.pushEnhancedEcommerce(track);
@@ -682,12 +682,12 @@ GA.prototype.refundedOrderEnhanced = function(track){
     var track = new Track({ properties: product });
     window.ga('ec:addProduct', {
       id: track.id() || track.sku(),
-      quantity: track.quantity(),
+      quantity: track.quantity()
     });
   });
 
   window.ga('ec:setAction', 'refund', {
-    id: orderId,
+    id: orderId
   });
 
   this.pushEnhancedEcommerce(track);
@@ -769,7 +769,7 @@ GA.prototype.viewedPromotionEnhanced = function(track){
     id: track.id(),
     name: track.name(),
     creative: props.creative,
-    position: props.position,
+    position: props.position
   });
   this.pushEnhancedEcommerce(track);
 };
@@ -790,7 +790,7 @@ GA.prototype.clickedPromotionEnhanced = function(track){
     id: track.id(),
     name: track.name(),
     creative: props.creative,
-    position: props.position,
+    position: props.position
   });
   ga('ec:setAction', 'promo_click', {});
   this.pushEnhancedEcommerce(track);
@@ -815,6 +815,7 @@ function enhancedEcommerceTrackProduct(track){
     price: track.price(),
     brand: props.brand,
     variant: props.variant,
+    currency: track.currency()
   });
 }
 
@@ -847,4 +848,17 @@ function extractCheckoutOptions(props){
   // Remove all nulls, empty strings, zeroes, and join with commas.
   var valid = select(options, function(e){return e; });
   return valid.length > 0 ? valid.join(', ') : null;
+}
+
+/**
+ * Creates a track out of product properties.
+ *
+ * @param {Track} track
+ * @param {Object} properties
+ * @return {Track}
+ */
+
+function createProductTrack(track, properties) {
+  properties.currency = properties.currency || track.currency();
+  return new Track({ properties: properties });
 }

--- a/lib/google-analytics/test.js
+++ b/lib/google-analytics/test.js
@@ -703,6 +703,7 @@ describe('Google Analytics', function(){
             price: 24.75,
             brand: undefined,
             variant: undefined,
+            currency: 'CAD'
           }]);
           analytics.deepEqual(window.ga.args[3], ['ec:setAction', 'add', {}]);
           analytics.deepEqual(window.ga.args[4], ['send', 'event', 'cat 1', 'added product', { nonInteraction: 1 }]);
@@ -728,6 +729,7 @@ describe('Google Analytics', function(){
             price: 24.75,
             brand: undefined,
             variant: undefined,
+            currency: 'CAD'
           }]);
           analytics.deepEqual(window.ga.args[3], ['ec:setAction', 'remove', {}]);
           analytics.deepEqual(window.ga.args[4], ['send', 'event', 'cat 1', 'removed product', { nonInteraction: 1 }]);
@@ -753,6 +755,7 @@ describe('Google Analytics', function(){
             price: 24.75,
             brand: undefined,
             variant: undefined,
+            currency: 'CAD'
           }]);
           analytics.deepEqual(window.ga.args[3], ['ec:setAction', 'detail', {}]);
           analytics.deepEqual(window.ga.args[4], ['send', 'event', 'cat 1', 'viewed product', { nonInteraction: 1 }]);
@@ -779,6 +782,7 @@ describe('Google Analytics', function(){
             price: 24.75,
             brand: undefined,
             variant: undefined,
+            currency: 'CAD'
           }]);
           analytics.deepEqual(window.ga.args[3], ['ec:setAction', 'click', {
             list: 'search results'
@@ -854,6 +858,7 @@ describe('Google Analytics', function(){
             price: 24.75,
             brand: undefined,
             variant: undefined,
+            currency: 'CAD'
           }]);
           analytics.deepEqual(window.ga.args[3], ['ec:addProduct', {
             id: 'p-299',
@@ -863,6 +868,7 @@ describe('Google Analytics', function(){
             price: 24.75,
             brand: undefined,
             variant: undefined,
+            currency: 'CAD'
           }]);
           analytics.deepEqual(window.ga.args[4], ['ec:setAction', 'checkout', {
             step: 1,
@@ -901,6 +907,7 @@ describe('Google Analytics', function(){
             price: 24.75,
             brand: undefined,
             variant: undefined,
+            currency: 'CAD'
           }]);
           analytics.deepEqual(window.ga.args[3], ['ec:addProduct', {
             id: 'p-299',
@@ -910,6 +917,7 @@ describe('Google Analytics', function(){
             price: 24.75,
             brand: undefined,
             variant: undefined,
+            currency: 'CAD'
           }]);
           analytics.deepEqual(window.ga.args[4], ['ec:setAction', 'checkout', {
             step: 1,
@@ -1018,7 +1026,8 @@ describe('Google Analytics', function(){
               price: 24.75,
               name: 'other product',
               category: 'cat 2',
-              sku: 'p-299'
+              sku: 'p-299',
+              currency: 'EUR'
             }]
           });
 
@@ -1032,6 +1041,7 @@ describe('Google Analytics', function(){
             price: 24.75,
             brand: undefined,
             variant: undefined,
+            currency: 'CAD'
           }]);
           analytics.deepEqual(window.ga.args[3], ['ec:addProduct', {
             id: 'p-299',
@@ -1041,6 +1051,7 @@ describe('Google Analytics', function(){
             price: 24.75,
             brand: undefined,
             variant: undefined,
+            currency: 'EUR'
           }]);
           analytics.deepEqual(window.ga.args[4], ['ec:setAction', 'purchase', {
             id: '780bc55',


### PR DESCRIPTION
Fixes a bug where `ecommerce:addItem` was sending `USD` instead of the currency sent in with original `track`. Also fixes bug where currency was not sent along with `ec:addProduct`. 

eg.

```
analytics.track("Completed Order", {"id":"#123","total":"21.40","revenue":"20.00","shipping":"0.00","tax":"1.40","currency":"GBP","products":[{"category":"Appliance","id":123,"sku":"","name":"Some product","price":"20.00","quantity":1,"brand":"Example Inc.","variant":""}]});
```

will currently result in a call to `https://www.google-analytics.com/collect` for `t=transaction` with `&cu=GBP` (correct) and another for the `t=item` with `&cu=USD` (default set in [facade](https://github.com/segmentio/facade/blob/master/lib/track.js#L152-L155)) - not correct).

Since currency is now taken from either the product properties or the track, the fix allows multi-currency purchases (not likely but allowed through GA).

@yields @DirtyAnalytics 
