### PR TITLE
FullStory IE8 Fix: dont mutate traits object while iterating

### DIFF
--- a/component.json
+++ b/component.json
@@ -62,7 +62,8 @@
     "segmentio/json": "^1.0.0",
     "component/reduce": "1.0.1",
     "ianstormtaylor/pick": "~0.1.0",
-    "harrietgrace/omit": "~0.1.0"
+    "harrietgrace/omit": "~0.1.0",
+    "ndhoule/foldl": "^1.0.1"
   },
   "development": {
     "component/jquery": "*",

--- a/lib/fullstory/index.js
+++ b/lib/fullstory/index.js
@@ -3,9 +3,8 @@
  * Module dependencies.
  */
 
-var each = require('each');
+var foldl = require('foldl');
 var is = require('is');
-var del = require('obj-case').del;
 var camel = require('to-camel-case');
 var integration = require('analytics.js-integration');
 
@@ -59,27 +58,14 @@ FullStory.prototype.loaded = function(){
 
 FullStory.prototype.identify = function(identify){
   var id = identify.userId() || identify.anonymousId();
-  var traits = identify.traits();
+  var traits = identify.traits({ name: 'displayName' });
 
-  del(traits, 'id');
+  var newTraits = foldl(function(results, value, key){
+    if (key !== 'id') results[key === 'displayName' || key === 'email' ? key : convert(key, value)] = value;
+    return results;
+  }, {}, traits);
 
-  if (identify.name()) {
-    traits.displayName = identify.name();
-    del(traits, 'name');
-  }
-
-  // Except for displayName and email
-  each(traits, function(trait, value){
-    if (trait !== 'displayName' && trait !== 'email') {
-      var newTrait = convert(trait, value);
-      traits[newTrait] = value;
-      del(traits, trait);
-    }
-  });
-
-  if (typeof id !== 'string') id = '' + id;
-
-  window.FS.identify(id, traits);
+  window.FS.identify(String(id), newTraits);
 };
 
 /**


### PR DESCRIPTION
Based off of feedback from the folks at FullStory! Apparently mutating the iteratee of the `each` here would change execution order in IE8 and cause the loop not to exit.  this just creates a new object and adds the converted traits to that one instead. @ndhoule @f2prateek 
