### PR TITLE
fix fb tests: send *conversions* not custom data

### DIFF
--- a/lib/facebook-conversion-tracking/test.js
+++ b/lib/facebook-conversion-tracking/test.js
@@ -13,7 +13,10 @@ describe('Facebook Conversion Tracking', function(){
     events: {
       signup: 0,
       login: 1,
-      play: 2
+      play: 2,
+      'Loaded a Page': 3,
+      'Viewed Name Page': 4,
+      'Viewed Category Name Page': 5
     }
   };
 
@@ -56,39 +59,27 @@ describe('Facebook Conversion Tracking', function(){
         analytics.stub(window._fbq, 'push');
       });
 
-      it('should track page view with fullname', function(){
-        analytics.page('Category', 'Name', { url: 'http://localhost:34448/test/' });
-        analytics.called(window._fbq.push, ['track', 'Viewed Category Name Page', {
-          url: 'http://localhost:34448/test/',
-          path: '/test/',
-          referrer: '',
-          title: 'integrations tests',
-          search: '',
-          name: 'Name',
-          category: 'Category'
-        }]);
-      });
-
       it('should track unnamed/categorized page', function(){
         analytics.page({ url: 'http://localhost:34448/test/' });
-        analytics.called(window._fbq.push, ['track', 'Loaded a Page', {
-          url: 'http://localhost:34448/test/',
-          path: '/test/',
-          referrer: '',
-          title: 'integrations tests',
-          search: ''
+        analytics.called(window._fbq.push, ['track', 3, {
+          currency: 'USD',
+          value: '0.00'
         }]);
       });
 
-      it('should track unnamed page', function(){
+      it('should track un-categorized page', function(){
         analytics.page('Name', { url: 'http://localhost:34448/test/' });
-        analytics.called(window._fbq.push, ['track', 'Viewed Name Page', {
-          url: 'http://localhost:34448/test/',
-          path: '/test/',
-          referrer: '',
-          title: 'integrations tests',
-          search: '',
-          name: 'Name'
+        analytics.called(window._fbq.push, ['track', 4, {
+          currency: 'USD',
+          value: '0.00'
+        }])
+      });
+
+      it('should track page view with fullname', function(){
+        analytics.page('Category', 'Name', { url: 'http://localhost:34448/test/' });
+        analytics.called(window._fbq.push, ['track', 5, {
+          currency: 'USD',
+          value: '0.00'
         }]);
       });
     });


### PR DESCRIPTION
spoke with @amillet89 about this. custom data belongs in the facebook custom audiences integration. this way, people can still map their page calls to _conversions_ if they need to, but we won't be conflating conversion tracking and custom audiences anymore.
