### PR TITLE
guard against optimizely.data.state being undefined

### DIFF
--- a/lib/optimizely/index.js
+++ b/lib/optimizely/index.js
@@ -83,7 +83,7 @@ Optimizely.prototype.replay = function(){
   if (!window.optimizely) return; // in case the snippet isnt on the page
 
   var data = window.optimizely.data;
-  if (!data) return;
+  if (!data || !data.state) return;
 
   var experiments = data.experiments;
   var map = data.state.variationNamesMap;


### PR DESCRIPTION
Add a guard for `data.state` being undefined. This happens when users opt-out of Optimizely experiments. 
