### PR TITLE
update to snapengage cdn

### DIFF
--- a/lib/snapengage/index.js
+++ b/lib/snapengage/index.js
@@ -14,7 +14,7 @@ var SnapEngage = module.exports = integration('SnapEngage')
   .assumesPageview()
   .global('SnapABug')
   .option('apiKey', '')
-  .tag('<script src="//commondatastorage.googleapis.com/code.snapengage.com/js/{{ apiKey }}.js">');
+  .tag('<script src="//www.snapengage.com/cdn/js/{{ apiKey }}.js">');
 
 /**
  * Initialize.


### PR DESCRIPTION
they were previously using the googleapis cdn, but it's blocked in china, so they are now using their own CDN for this

ticket convo here with the snapengage team: https://segment.zendesk.com/agent/tickets/26378
