### PR TITLE
add support for inspectlet's 'identify' call

### DIFF
--- a/lib/inspectlet/index.js
+++ b/lib/inspectlet/index.js
@@ -52,6 +52,8 @@ Inspectlet.prototype.loaded = function(){
 
 Inspectlet.prototype.identify = function(identify){
   var traits = identify.traits({ id: 'userid' });
+  var email = identify.email();
+  if (email) push('identify', email);
   push('tagSession', traits);
 };
 

--- a/lib/inspectlet/test.js
+++ b/lib/inspectlet/test.js
@@ -87,6 +87,7 @@ describe('Inspectlet', function(){
           email: 'email@example.com',
           userid: 'userId'
         }]);
+	analytics.called(window.__insp.push, ['identify', 'email@example.com']);
       });
     });
 


### PR DESCRIPTION
Inspectlet has an optional identify method for the user's display name in their UI. Looks like they prefer using the user's email for that so that's what we've mapped here!

@hankim813 @f2prateek 

Related ticket: https://segment.zendesk.com/agent/tickets/26909

Related documentation: https://www.inspectlet.com/docs#identifying_users
