### PR TITLE
Mixpanel: put trait -> super property registration behind option (default = true)

### DIFF
--- a/lib/mixpanel/index.js
+++ b/lib/mixpanel/index.js
@@ -26,6 +26,7 @@ var Mixpanel = module.exports = integration('Mixpanel')
   .option('nameTag', true)
   .option('pageview', false)
   .option('people', false)
+  .option('superTraits', true)
   .option('token', '')
   .option('trackAllPages', false)
   .option('trackNamedPages', true)
@@ -139,7 +140,7 @@ Mixpanel.prototype.identify = function(identify){
   // traits
   var traits = identify.traits(traitAliases);
   if (traits.$created) del(traits, 'createdAt');
-  window.mixpanel.register(dates(traits, iso));
+  if (this.options.superTraits) window.mixpanel.register(dates(traits, iso));
   if (this.options.people) window.mixpanel.people.set(traits);
 };
 

--- a/lib/mixpanel/test.js
+++ b/lib/mixpanel/test.js
@@ -41,6 +41,7 @@ describe('Mixpanel', function(){
       .option('nameTag', true)
       .option('pageview', false)
       .option('people', false)
+      .option('superTraits', true)
       .option('token', '')
       .option('trackAllPages', false)
       .option('trackNamedPages', true));
@@ -144,6 +145,12 @@ describe('Mixpanel', function(){
       it('should send traits', function(){
         analytics.identify({ trait: true });
         analytics.called(window.mixpanel.register, { trait: true });
+      });
+
+      it('should not send traits when "Send Traits as Super Properties" is false', function(){
+        mixpanel.options.superTraits = false;
+        analytics.identify({ trait: true });
+        analytics.didNotCall(window.mixpanel.register);
       });
 
       it('should send an id and traits', function(){


### PR DESCRIPTION
**IMPORTANT** before merging this needs metadata update:

```
"options": {
 ...,
 "superTraits": {
      "default": true,
      "description": "This will register `traits` passed to `analytics.identify` as Mixpanel Super Properties, which are properties automatically attached to all events sent from the client.",
      "label": "Register Traits as Super Properties",
      "type": "boolean"
    },
...
}
```

Context: https://segment.zendesk.com/agent/tickets/26510

Spoke with @ianstormtaylor and he agreed it makes sense to put this behind a flag with a default to true. User traits and super properties are semantically quite different now that people properties are a thing, so it makes sense that automatically conflating them be optional :)
