### PR TITLE
Intercom: Allow `page` to be called independently of `identify`

### DIFF
--- a/lib/intercom/index.js
+++ b/lib/intercom/index.js
@@ -24,7 +24,6 @@ var Intercom = module.exports = integration('Intercom')
   .global('Intercom')
   .option('activator', '#IntercomDefaultWidget')
   .option('appId', '')
-  .option('inbox', false)
   .tag('<script src="https://widget.intercom.io/widget/{{ appId }}">');
 
 /**

--- a/lib/intercom/index.js
+++ b/lib/intercom/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -12,7 +11,6 @@ var load = require('load-script');
 var empty = require('is-empty');
 var alias = require('alias');
 var each = require('each');
-var when = require('when');
 var is = require('is');
 
 /**
@@ -20,7 +18,6 @@ var is = require('is');
  */
 
 var Intercom = module.exports = integration('Intercom')
-  .assumesPageview()
   .global('Intercom')
   .option('activator', '#IntercomDefaultWidget')
   .option('appId', '')
@@ -36,10 +33,8 @@ var Intercom = module.exports = integration('Intercom')
  */
 
 Intercom.prototype.initialize = function(page){
-  var self = this;
-  this.load(function(){
-    when(function(){ return self.loaded(); }, self.ready);
-  });
+  initialize();
+  this.load(this.ready);
 };
 
 /**
@@ -58,8 +53,8 @@ Intercom.prototype.loaded = function(){
  * @param {Page} page
  */
 
-Intercom.prototype.page = function(page){
-  window.Intercom('update');
+Intercom.prototype.page = function(){
+  this.bootOrUpdate();
 };
 
 /**
@@ -72,7 +67,6 @@ Intercom.prototype.page = function(page){
 
 Intercom.prototype.identify = function(identify){
   var traits = identify.traits({ userId: 'user_id' });
-  var activator = this.options.activator;
   var opts = identify.options(this.name);
   var companyCreated = identify.companyCreated();
   var created = identify.created();
@@ -81,14 +75,19 @@ Intercom.prototype.identify = function(identify){
   var id = identify.userId();
   var group = this.analytics.group();
 
-  if (!id && !traits.email) return; // one is required
-
-  traits.app_id = this.options.appId;
+  if (!id && !traits.email) {
+    return;
+  }
 
   // intercom requires `company` to be an object. default it with group traits
   // so that we guarantee an `id` is there, since they require it
-  if (null != traits.company && !is.object(traits.company)) delete traits.company;
-  if (traits.company) defaults(traits.company, group.traits());
+  if (traits.company !== null && !is.object(traits.company)) {
+    delete traits.company;
+  }
+
+  if (traits.company) {
+    defaults(traits.company, group.traits());
+  }
 
   // name
   if (name) traits.name = name;
@@ -99,6 +98,7 @@ Intercom.prototype.identify = function(identify){
     del(traits, 'createdAt');
     traits.created_at = created;
   }
+
   if (companyCreated) {
     del(traits.company, 'created');
     del(traits.company, 'createdAt');
@@ -113,18 +113,7 @@ Intercom.prototype.identify = function(identify){
   if (opts.userHash) traits.user_hash = opts.userHash;
   if (opts.user_hash) traits.user_hash = opts.user_hash;
 
-  // Intercom, will force the widget to appear
-  // if the selector is #IntercomDefaultWidget
-  // so no need to check inbox, just need to check
-  // that the selector isn't #IntercomDefaultWidget.
-  if ('#IntercomDefaultWidget' != activator) {
-    traits.widget = { activator: activator };
-  }
-
-  var method = this._id !== id ? 'boot': 'update';
-  this._id = id; // cache for next time
-
-  window.Intercom(method, traits);
+  this.bootOrUpdate(traits);
 };
 
 /**
@@ -139,7 +128,7 @@ Intercom.prototype.group = function(group){
   props = alias(props, { created: 'created_at' });
   var id = group.groupId();
   if (id) props.id = id;
-  window.Intercom('update', { company: props });
+  api('update', { company: props });
 };
 
 /**
@@ -149,7 +138,31 @@ Intercom.prototype.group = function(group){
  */
 
 Intercom.prototype.track = function(track){
-  window.Intercom('trackEvent', track.event(), track.properties());
+  api('trackEvent', track.event(), track.properties());
+};
+
+/**
+ * Boots or updates, as appropriate.
+ *
+ * @param {Object} options
+ */
+
+Intercom.prototype.bootOrUpdate = function(options){
+  options = options || {};
+  var method = this.booted === true ? 'update' : 'boot';
+  var activator = this.options.activator;
+  options.app_id = this.options.appId;
+
+  // Intercom, will force the widget to appear
+  // if the selector is #IntercomDefaultWidget
+  // so no need to check inbox, just need to check
+  // that the selector isn't #IntercomDefaultWidget.
+  if (activator !== '#IntercomDefaultWidget') {
+    options.widget = { activator: activator };
+  }
+
+  api(method, options);
+  this.booted = true;
 };
 
 /**
@@ -159,6 +172,25 @@ Intercom.prototype.track = function(track){
  * @return {Number}
  */
 
-function formatDate(date) {
+function formatDate(date){
   return Math.floor(date / 1000);
+}
+
+/**
+ * Initialize the Intercom call queue.
+ */
+
+function initialize(){
+  window.Intercom = function(){
+    window.Intercom.q.push(arguments);
+  };
+  window.Intercom.q = [];
+}
+
+/**
+ * Push a call onto the queue.
+ */
+
+function api(){
+  window.Intercom.apply(window.Intercom, arguments);
 }

--- a/lib/intercom/index.js
+++ b/lib/intercom/index.js
@@ -25,7 +25,7 @@ var Intercom = module.exports = integration('Intercom')
   .option('activator', '#IntercomDefaultWidget')
   .option('appId', '')
   .option('inbox', false)
-  .tag('<script src="https://static.intercomcdn.com/intercom.v1.js">');
+  .tag('<script src="https://widget.intercom.io/widget/{{ appId }}">');
 
 /**
  * Initialize.

--- a/lib/intercom/test.js
+++ b/lib/intercom/test.js
@@ -14,7 +14,7 @@ describe('Intercom', function(){
   };
 
   beforeEach(function(){
-    analytics = new Analytics;
+    analytics = new Analytics();
     intercom = new Intercom(options);
     analytics.use(plugin);
     analytics.use(tester);
@@ -30,7 +30,6 @@ describe('Intercom', function(){
 
   it('should have the right settings', function(){
     analytics.compare(Intercom, integration('Intercom')
-      .assumesPageview()
       .global('Intercom')
       .option('activator', '#IntercomDefaultWidget')
       .option('appId', '')
@@ -43,6 +42,13 @@ describe('Intercom', function(){
     });
 
     describe('#initialize', function(){
+      it('should create window.Intercom', function(){
+        analytics.assert(!window.Intercom);
+        analytics.initialize();
+        analytics.page();
+        analytics.assert(window.Intercom);
+      });
+
       it('should call #load', function(){
         analytics.initialize();
         analytics.page();
@@ -61,7 +67,6 @@ describe('Intercom', function(){
     beforeEach(function(done){
       analytics.once('ready', done);
       analytics.initialize();
-      analytics.page();
     });
 
     describe('#page', function(){
@@ -69,9 +74,16 @@ describe('Intercom', function(){
         analytics.stub(window, 'Intercom');
       });
 
-      it('should call update on subsequent pageviews', function(){
+      it('should call boot first and update subsequently', function(){
         analytics.page();
-        analytics.called(window.Intercom, 'update');
+        analytics.called(window.Intercom, 'boot', {
+          app_id: options.appId
+        });
+
+        analytics.page();
+        analytics.called(window.Intercom, 'update', {
+          app_id: options.appId
+        });
       });
     });
 
@@ -80,7 +92,7 @@ describe('Intercom', function(){
         analytics.stub(window, 'Intercom');
       });
 
-      it('should call boot the first time and update the second', function(){
+      it('should call boot first and update subsequently', function(){
         analytics.identify('id');
         analytics.called(window.Intercom, 'boot', {
           app_id: options.appId,

--- a/lib/intercom/test.js
+++ b/lib/intercom/test.js
@@ -34,7 +34,8 @@ describe('Intercom', function(){
       .global('Intercom')
       .option('activator', '#IntercomDefaultWidget')
       .option('appId', '')
-      .option('inbox', false));
+      .option('inbox', false)
+      .tag('<script src="https://widget.intercom.io/widget/{{ appId }}">'));
   });
 
   describe('before loading', function(){

--- a/lib/intercom/test.js
+++ b/lib/intercom/test.js
@@ -34,7 +34,6 @@ describe('Intercom', function(){
       .global('Intercom')
       .option('activator', '#IntercomDefaultWidget')
       .option('appId', '')
-      .option('inbox', false)
       .tag('<script src="https://widget.intercom.io/widget/{{ appId }}">'));
   });
 


### PR DESCRIPTION
Hey folks! We (@intercom) are going to support 'anonymous' users very soon. This PR makes it possible to call `page` independently of `identify`.

I also slipped in two other minor changes.
- Update the tag src for the intercom script.
- Remove the deprecated `inbox` option.
