### PR TITLE
fix pageview call

### DIFF
--- a/lib/hubspot/index.js
+++ b/lib/hubspot/index.js
@@ -49,7 +49,7 @@ HubSpot.prototype.loaded = function(){
  */
 
 HubSpot.prototype.page = function(page){
-  push('_trackPageview');
+  push('trackPageView');
 };
 
 /**

--- a/lib/hubspot/test.js
+++ b/lib/hubspot/test.js
@@ -130,7 +130,7 @@ describe('HubSpot', function(){
 
       it('should send a page view', function(){
         analytics.page();
-        analytics.called(window._hsq.push, ['_trackPageview']);
+        analytics.called(window._hsq.push, ['trackPageView']);
       });
     });
   });


### PR DESCRIPTION
`_trackPageview` does nothing (no network activity) when pushed onto their `_hsq` global queue, but `trackPageView` has the desired effect. Ascertained via their script (which calls it automatically on load):

![](https://cloudup.com/cr7E2SLiVEi+)

props to @hankim813 for discovering!
