### PR TITLE
Fix/send traits to mixpanel people

### DIFF
--- a/lib/mixpanel/index.js
+++ b/lib/mixpanel/index.js
@@ -140,7 +140,7 @@ Mixpanel.prototype.identify = function(identify){
   var traits = identify.traits(traitAliases);
   if (traits.$created) del(traits, 'createdAt');
   window.mixpanel.register(dates(traits, iso));
-  if (this.options.people) window.mixpanel.people.set(traits);
+  if (this.options.people && id) window.mixpanel.people.set(traits);
 };
 
 /**

--- a/lib/mixpanel/test.js
+++ b/lib/mixpanel/test.js
@@ -172,8 +172,8 @@ describe('Mixpanel', function(){
 
       it('should send traits to Mixpanel People', function(){
         mixpanel.options.people = true;
-        analytics.identify({ trait: true });
-        analytics.called(window.mixpanel.people.set, { trait: true });
+        analytics.identify('id', { trait: true });
+        analytics.called(window.mixpanel.people.set, { id: 'id', trait: true });
       });
 
       it('should alias traits', function(){
@@ -203,7 +203,7 @@ describe('Mixpanel', function(){
       it('should alias traits to Mixpanel People', function(){
         mixpanel.options.people = true;
         var date = new Date();
-        analytics.identify({
+        analytics.identify('id', {
           created: date,
           email: 'name@example.com',
           firstName: 'first',
@@ -221,14 +221,15 @@ describe('Mixpanel', function(){
           $last_seen: date,
           $name: 'name',
           $username: 'username',
-          $phone: 'phone'
+          $phone: 'phone',
+          id: 'id'
         });
       });
 
       it('should remove .created_at', function(){
         mixpanel.options.people = true;
         var date = new Date();
-        analytics.identify({
+        analytics.identify('id', {
           created_at: date,
           email: 'name@example.com',
           firstName: 'first',
@@ -246,7 +247,8 @@ describe('Mixpanel', function(){
           $last_seen: date,
           $name: 'name',
           $username: 'username',
-          $phone: 'phone'
+          $phone: 'phone',
+          id: 'id'
         });
       })
     });


### PR DESCRIPTION
Uncovered an unusual bug with Mixpanel with @DirtyAnalytics:
http://screencast.com/t/VOqoVfipBAHj

Basically, `.identify()`, then `.alias(userId)`, then `.identify(userId)` will create duplicate profiles in Mixpanel.

We are sending `traits` to mixpanel people even without a `userId`:
https://github.com/segmentio/analytics.js-integrations/blob/master/lib/mixpanel/index.js#L143

This PR now requires `userId` in order to set `traits` to Mixpanel. However, this PR will also break many people's current client side segment/mixpanel integrations, even though this is the right way. if someone is calling `.identify()` without `userId` it creates a people profile in Mixpanel. but now it won't. its possible someone is using that way.

/cc @amillet89 @sperand-io 

Related ticket: https://segment.zendesk.com/agent/tickets/27509
