### PR TITLE
adding anonymousId closes #601

### DIFF
--- a/lib/insidevault/index.js
+++ b/lib/insidevault/index.js
@@ -36,7 +36,7 @@ InsideVault.prototype.initialize = function(page){
   var domain = this.options.domain;
   window._iva = window._iva || [];
   push('setClientId', this.options.clientId);
-  var userId = this.analytics.user().id();
+  var userId = this.analytics.user().anonymousId();
   if (userId) push('setUserId', userId);
   if (domain) push('setDomain', domain);
   this.load(this.ready);
@@ -59,7 +59,7 @@ InsideVault.prototype.loaded = function(){
  */
 
 InsideVault.prototype.identify = function(identify){
-  push('setUserId', identify.userId());
+  push('setUserId', identify.anonymousId());
 };
 
 /**
@@ -85,7 +85,7 @@ InsideVault.prototype.track = function(track){
   var user = this.analytics.user();
   var events = this.events(track.event());
   var value = track.revenue() || track.value() || 0;
-  var eventId = track.orderId() || user.id() || '';
+  var eventId = track.orderId() || user.anonymousId() || '';
   each(events, function(event){
     // 'sale' is a special event that will be routed to a table that is deprecated on InsideVault's end.
     // They don't want a generic 'sale' event to go to their deprecated table.

--- a/lib/insidevault/test.js
+++ b/lib/insidevault/test.js
@@ -64,7 +64,7 @@ describe('InsideVault', function(){
       it('should pass in userId', function(){
         window._iva = [];
         analytics.stub(window._iva, 'push');
-        analytics.identify('user-id');
+        analytics.user().anonymousId('user-id');
         analytics.initialize();
         analytics.page();
         analytics.called(window._iva.push, ['setUserId', 'user-id']);
@@ -119,18 +119,21 @@ describe('InsideVault', function(){
       });
 
       it('should track an event', function(){
+        analytics.user().anonymousId('id');
         analytics.track('sign up');
-        analytics.called(window._iva.push, ['trackEvent', 'event1', 0, '']);
+        analytics.called(window._iva.push, ['trackEvent', 'event1', 0, 'id']);
       });
 
       it('should track an event with revenue', function(){
+        analytics.user().anonymousId('id');
         analytics.track('completed order', { revenue: '0.75' });
-        analytics.called(window._iva.push, ['trackEvent', 'event2', 0.75, '']);
+        analytics.called(window._iva.push, ['trackEvent', 'event2', 0.75, 'id']);
       });
 
       it('should track an event with value', function(){
+        analytics.user().anonymousId('id');
         analytics.track('completed order', { value: 1.23 });
-        analytics.called(window._iva.push, ['trackEvent', 'event2', 1.23, '']);
+        analytics.called(window._iva.push, ['trackEvent', 'event2', 1.23, 'id']);
       });
 
       it('should track an event with revenue and order id', function(){
@@ -139,13 +142,13 @@ describe('InsideVault', function(){
       });
 
       it('should track an event with userId and orderId, using orderId', function(){
-        analytics.identify('id');
+        analytics.user().anonymousId('id');
         analytics.track('completed order', { orderId: 'abc123' });
         analytics.called(window._iva.push, ['trackEvent', 'event2', 0, 'abc123']);
       });
 
       it('should fall back to userId if no orderId', function(){
-        analytics.identify('id');
+        analytics.user().anonymousId('id');
         analytics.track('sign up');
         analytics.called(window._iva.push, ['trackEvent', 'event1', 0, 'id']);
       });


### PR DESCRIPTION
Inside Vault needs to be able to tie back users pre and post conversion and can only accept 1 id.
For this reason, we should send through the anonymousID on line 17 where we send through the userID.

https://github.com/segmentio/integrations-private/blob/master/lib/inside-vault/index.js#L17
