### PR TITLE
Don't identify on intercom without the user_hash

### DIFF
--- a/lib/intercom/index.js
+++ b/lib/intercom/index.js
@@ -75,7 +75,11 @@ Intercom.prototype.identify = function(identify){
   var id = identify.userId();
   var group = this.analytics.group();
 
-  if (!id && !traits.email) {
+  // handle user_hash
+  if (opts.userHash) traits.user_hash = opts.userHash;
+  if (opts.user_hash) traits.user_hash = opts.user_hash;
+
+  if ((!id && !traits.email) || !traits.user_hash) {
     return;
   }
 
@@ -110,8 +114,6 @@ Intercom.prototype.identify = function(identify){
 
   // handle options
   if (opts.increments) traits.increments = opts.increments;
-  if (opts.userHash) traits.user_hash = opts.userHash;
-  if (opts.user_hash) traits.user_hash = opts.user_hash;
 
   this.bootOrUpdate(traits);
 };

--- a/lib/intercom/test.js
+++ b/lib/intercom/test.js
@@ -93,62 +93,80 @@ describe('Intercom', function(){
       });
 
       it('should call boot first and update subsequently', function(){
-        analytics.identify('id');
+        analytics.identify('id', {}, {
+          Intercom: { userHash: 'x' }
+        });
         analytics.called(window.Intercom, 'boot', {
           app_id: options.appId,
           user_id: 'id',
-          id: 'id'
+          id: 'id',
+          user_hash: 'x'
         });
 
-        analytics.identify('id');
+        analytics.identify('id', {}, {
+          Intercom: { userHash: 'x' }
+        });
         analytics.called(window.Intercom, 'update', {
           app_id: options.appId,
           user_id: 'id',
-          id: 'id'
+          id: 'id',
+          user_hash: 'x'
         });
       });
 
       it('should send an id and traits', function(){
-        analytics.identify('id', { email: 'email@example.com' });
+        analytics.identify('id', { email: 'email@example.com' }, {
+          Intercom: { userHash: 'x' }
+        });
         analytics.called(window.Intercom, 'boot', {
           email: 'email@example.com',
           app_id: options.appId,
           user_id: 'id',
-          id: 'id'
+          id: 'id',
+          user_hash: 'x'
         });
       });
 
       it('should send user name', function(){
-        analytics.identify('id', { name: 'john doe' });
+        analytics.identify('id', { name: 'john doe' }, {
+          Intercom: { userHash: 'x' }
+        });
         analytics.called(window.Intercom, 'boot', {
           app_id: options.appId,
           user_id: 'id',
           name: 'john doe',
-          id: 'id'
+          id: 'id',
+          user_hash: 'x'
         });
       });
 
       it('should send first and last as name', function(){
-        analytics.identify('id', { firstName: 'john', lastName: 'doe' });
+        analytics.identify('id', { firstName: 'john', lastName: 'doe' }, {
+          Intercom: { userHash: 'x' }
+        });
         analytics.called(window.Intercom, 'boot', {
           app_id: options.appId,
           user_id: 'id',
           firstName: 'john',
           lastName: 'doe',
           name: 'john doe',
-          id: 'id'
+          id: 'id',
+          user_hash: 'x'
         });
       });
 
       it('should respect .name, .firstName and .lastName', function(){
-        analytics.identify('id', { firstName: 'john', lastName: 'doe', name: 'baz' });
+        analytics.identify('id', { firstName: 'john', lastName: 'doe', name: 'baz' }, {
+          Intercom: { userHash: 'x' }
+        });
         analytics.called(window.Intercom, 'boot', {
           app_id: options.appId,
           user_id: 'id',
           firstName: 'john',
           lastName: 'doe',
           name: 'baz',
-          id: 'id'
+          id: 'id',
+          user_hash: 'x'
         });
       });
 
@@ -159,6 +177,8 @@ describe('Intercom', function(){
           analytics.identify('id', {
             created: date,
             company: { created: date }
+          }, {
+            Intercom: { userHash: 'x' }
           });
 
           analytics.called(window.Intercom, 'boot', {
@@ -166,7 +186,8 @@ describe('Intercom', function(){
             user_id: 'id',
             created_at: Math.floor(date / 1000),
             company: { created_at: Math.floor(date / 1000) },
-            id: 'id'
+            id: 'id',
+            user_hash: 'x'
           });
         });
 
@@ -178,6 +199,8 @@ describe('Intercom', function(){
           analytics.identify('12345', {
             createdAt: isoDate,
             company: { created: isoDate }
+          }, {
+            Intercom: { userHash: 'x' }
           });
 
           analytics.called(window.Intercom, 'boot', {
@@ -185,7 +208,8 @@ describe('Intercom', function(){
             user_id: '12345',
             created_at: unixDate,
             company: { created_at: unixDate },
-            id: '12345'
+            id: '12345',
+            user_hash: 'x'
           });
         });
 
@@ -195,6 +219,8 @@ describe('Intercom', function(){
           analytics.identify('12345', {
             createdAt: date,
             company: { created: date }
+          }, {
+            Intercom: { userHash: 'x' }
           });
 
           analytics.called(window.Intercom, 'boot', {
@@ -202,7 +228,8 @@ describe('Intercom', function(){
             user_id: '12345',
             created_at: date,
             company: { created_at: date },
-            id: '12345'
+            id: '12345',
+            user_hash: 'x'
           });
         });
 
@@ -212,6 +239,8 @@ describe('Intercom', function(){
           analytics.identify('12345', {
             createdAt: date,
             company: { created: date }
+          }, {
+            Intercom: { userHash: 'x' }
           });
 
           analytics.called(window.Intercom, 'boot', {
@@ -219,42 +248,47 @@ describe('Intercom', function(){
             user_id: '12345',
             created_at: Math.floor(date / 1000),
             company: { created_at: Math.floor(date / 1000) },
-            id: '12345'
+            id: '12345',
+            user_hash: 'x'
           });
         });
       });
 
-      it('should allow passing a user hash', function(){
-        analytics.identify('id', {}, {
-          Intercom: { userHash: 'x' }
-        });
-        analytics.called(window.Intercom, 'boot', {
+      it('should fail without passing a user hash', function(){
+        analytics.identify('id');
+        analytics.didNotCall(window.Intercom, 'boot', {
           app_id: options.appId,
           user_id: 'id',
-          user_hash: 'x',
           id: 'id'
         });
       });
 
       it('should allow passing increments', function(){
         analytics.identify('id', {}, {
-          Intercom: { increments: { number: 42 } }
+          Intercom: {
+            increments: { number: 42 },
+            userHash: 'x'
+          }
         });
         analytics.called(window.Intercom, 'boot', {
           app_id: options.appId,
           user_id: 'id',
           increments: { number: 42 },
-          id: 'id'
+          id: 'id',
+          user_hash: 'x'
         });
       });
 
       it('should send widget settings if the activator isnt the default one.', function(){
         intercom.options.activator = '#my-widget';
-        analytics.identify('id');
+        analytics.identify('id', {}, {
+          Intercom: { userHash: 'x' }
+        });
         analytics.called(window.Intercom, 'boot', {
           app_id: options.appId,
           user_id: 'id',
           id: 'id',
+          user_hash: 'x',
           widget: {
             activator: '#my-widget'
           }
@@ -262,39 +296,51 @@ describe('Intercom', function(){
       });
 
       it('should not send activator if its the default one.', function(){
-        analytics.identify('id');
+        analytics.identify('id', {}, {
+          Intercom: { userHash: 'x' }
+        });
         analytics.called(window.Intercom, 'boot', {
           app_id: options.appId,
           user_id: 'id',
-          id: 'id'
+          id: 'id',
+          user_hash: 'x'
         });
       });
 
       it('should not fail when the company trait is a string', function(){
-        analytics.identify('id', { company: 'string' });
+        analytics.identify('id', { company: 'string' }, {
+          Intercom: { userHash: 'x' }
+        });
         analytics.called(window.Intercom, 'boot', {
           app_id: options.appId,
           user_id: 'id',
-          id: 'id'
+          id: 'id',
+          user_hash: 'x'
         });
       });
 
       it('should not fail when the company trait is a number', function(){
-        analytics.identify('id', { company: 97 });
+        analytics.identify('id', { company: 97 }, {
+          Intercom: { userHash: 'x' }
+        });
         analytics.called(window.Intercom, 'boot', {
           app_id: options.appId,
           user_id: 'id',
-          id: 'id'
+          id: 'id',
+          user_hash: 'x'
         });
       });
 
       it('should carry over company traits set in group if a company trait exists', function(){
         analytics.group().traits({ foo: 'bar' });
-        analytics.identify('id', { company: { name: 'name' }});
+        analytics.identify('id', { company: { name: 'name' }}, {
+          Intercom: { userHash: 'x' }
+        });
         analytics.called(window.Intercom, 'boot', {
           app_id: options.appId,
           user_id: 'id',
           id: 'id',
+          user_hash: 'x',
           company: {
             name: 'name',
             foo: 'bar'


### PR DESCRIPTION
[Secure mode](http://docs.intercom.io/configuring-Intercom/enable-secure-mode) is now the default on Intercom and there doesn't seem like you can turn it off.  As such segment should no longer be identifying with intercom if the `user_hash` is missing.

I've updated the intercom integration to reflect this along with all the tests.

It's outside of the scope of this pull request but I would also suggest that segment caches the `user_hash`.  Since the `user_id` is already cached it would allow `identify` to work on just cached data.
