### PR TITLE
Adroll: updates and fixes

### DIFF
--- a/lib/adroll/index.js
+++ b/lib/adroll/index.js
@@ -26,8 +26,10 @@ var AdRoll = module.exports = integration('AdRoll')
   .global('adroll_adv_id')
   .global('adroll_pix_id')
   .global('adroll_custom_data')
+  .global('adroll_email')
   .option('advId', '')
   .option('pixId', '')
+  .option('v1', false)
   .tag('http', '<script src="http://a.adroll.com/j/roundtrip.js">')
   .tag('https', '<script src="https://s.adroll.com/j/roundtrip.js">')
   .mapping('events');
@@ -73,6 +75,16 @@ AdRoll.prototype.page = function(page){
 };
 
 /**
+ * Identify.
+ *
+ * @param {Identify} identify
+ */
+
+AdRoll.prototype.identify = function(identify){
+    if (identify.email()) window.adroll_email = identify.email();
+}
+
+/**
  * Track.
  *
  * @param {Track} track
@@ -87,6 +99,7 @@ AdRoll.prototype.track = function(track){
   var productId = track.id();
   var sku = track.sku();
   var customProps = track.properties();
+  var self = this;
 
   var data = {};
   if (user.id()) data.user_id = user.id();
@@ -99,17 +112,23 @@ AdRoll.prototype.track = function(track){
   del(customProps, "orderId");
   del(customProps, "id");
   del(customProps, "sku");
-  if (!is.empty(customProps)) data.adroll_custom_data = customProps;
+  if (!is.empty(customProps)) {
+    each(customProps, function(key, val){
+      data[snake(key)] = val;
+    });
+  }
 
   each(events, function(event){
-    // the adroll interface only allows for
-    // segment names which are snake cased.
-    data.adroll_segments = snake(event);
+    data.adroll_segments = self.options.v1 ? snake(event) : event
     window.__adroll.record_user(data);
   });
 
-  // no events found
-  if (!events.length) {
+  // no events found. only send this event if v1,
+  // as adroll no longer accepts segment by name
+  // and instead only by segment id
+  // new customers must map *all* events that they want
+  // sent to adroll in the interface
+  if (this.options.v1 && !events.length){
     data.adroll_segments = snake(event);
     window.__adroll.record_user(data);
   }

--- a/lib/adroll/test.js
+++ b/lib/adroll/test.js
@@ -11,7 +11,8 @@ describe('AdRoll', function(){
   var analytics;
   var options = {
     advId: 'FSQJWMMZ2NEAZH6XWKVCNO',
-    pixId: 'N6HGWT4ALRDRXCAO5PLTB6'
+    pixId: 'N6HGWT4ALRDRXCAO5PLTB6',
+    v1: false
   };
 
   beforeEach(function(){
@@ -35,11 +36,12 @@ describe('AdRoll', function(){
       .global('__adroll_loaded')
       .global('adroll_adv_id')
       .global('adroll_pix_id')
-      .global('adroll_custom_data')
+      .global('adroll_email')
       .option('advId', '')
       .option('pixId', '')
+      .option('v1', false)
       .mapping('events'));
-  });
+});
 
   describe('before loading', function(){
     beforeEach(function(){
@@ -78,13 +80,12 @@ describe('AdRoll', function(){
         it('should not set a user id', function(){
           analytics.initialize();
           analytics.page();
-          analytics.assert(!window.adroll_custom_data);
-        });
       });
     });
   });
+});
 
-  describe('loading', function(){
+describe('loading', function(){
     it('should load', function(done){
       analytics.load(adroll, done);
     });
@@ -97,68 +98,104 @@ describe('AdRoll', function(){
       analytics.page();
     });
 
+    describe('#identify', function(){
+      it('should pass email', function(){
+        analytics.identify('id', { email: 'test@email.com' });
+        analytics.equal('test@email.com', window.adroll_email);
+      });
+
+      it('should not pass empty email', function(){
+        analytics.identify('id', {});
+        analytics.assert(!window.adroll_email);
+      });
+    });
+
     describe('#page', function(){
       beforeEach(function(){
         analytics.stub(window.__adroll, 'record_user');
       });
 
-      it('should track page view with fullName', function(){
-        analytics.page('Category', 'Name', { url: 'http://localhost:34448/test/' });
-        analytics.called(window.__adroll.record_user, {
-        adroll_segments: 'viewed_category_name_page',
-        adroll_custom_data: {
-          path: '/test/',
-          referrer: '',
-          title: 'integrations tests',
-          search: '',
-          name: 'Name',
-          category: 'Category',
-          url: 'http://localhost:34448/test/'
-        }
+      describe('v1: segment names', function(){
+        beforeEach(function(){
+          adroll.options.v1 = true;
         });
-      });
 
-      it('should track unnamed/categorized page', function(){
-        analytics.page({ url: 'http://localhost:34448/test/' });
-        analytics.called(window.__adroll.record_user, {
-          adroll_segments: 'loaded_a_page',
-          adroll_custom_data: {
+        it('should track page view with fullName', function(){
+          analytics.page('Category', 'Name', { url: 'http://localhost:34448/test/' });
+          analytics.called(window.__adroll.record_user, {
+            adroll_segments: 'viewed_category_name_page',
+            path: '/test/',
+            referrer: '',
+            title: 'integrations tests',
+            search: '',
+            name: 'Name',
+            category: 'Category',
+            url: 'http://localhost:34448/test/'
+          });
+        });
+
+        it('should track unnamed/categorized page', function(){
+          analytics.page({ url: 'http://localhost:34448/test/' });
+          analytics.called(window.__adroll.record_user, {
+            adroll_segments: 'loaded_a_page',
             path: '/test/',
             referrer: '',
             title: 'integrations tests',
             search: '',
             url: 'http://localhost:34448/test/'
-          }
+          });
         });
-      });
 
-      it('should track unnamed page', function(){
-        analytics.page('Name', { url: 'http://localhost:34448/test/' });
-        analytics.called(window.__adroll.record_user, {
-          adroll_segments: 'viewed_name_page',
-          adroll_custom_data: {
+        it('should track unnamed page', function(){
+          analytics.page('Name', { url: 'http://localhost:34448/test/' });
+          analytics.called(window.__adroll.record_user, {
+            adroll_segments: 'viewed_name_page',
             path: '/test/',
             referrer: '',
             title: 'integrations tests',
             search: '',
             name: 'Name',
             url: 'http://localhost:34448/test/'
-          }
+          });
         });
-      });
 
-      it('should track uncategorized page', function(){
-        analytics.page('Name', { url: 'http://localhost:34448/test/' });
-        analytics.called(window.__adroll.record_user, {
-          adroll_segments: 'viewed_name_page',
-          adroll_custom_data: {
+        it('should track uncategorized page', function(){
+          analytics.page('Name', { url: 'http://localhost:34448/test/' });
+          analytics.called(window.__adroll.record_user, {
+            adroll_segments: 'viewed_name_page',
             path: '/test/',
             referrer: '',
             title: 'integrations tests',
             search: '',
             name: 'Name',
             url: 'http://localhost:34448/test/'
-          }
+          });
+        });
+      });
+
+      describe('v2: segment ids', function(){
+        beforeEach(function(){
+          adroll.options.events = { 'Viewed Category Name Page': '123' };
+          adroll.options.v1 = false;
+        });
+
+        it('should track mapped page views', function(){
+          analytics.page('Category', 'Name', { url: 'http://localhost:34448/test/' });
+          analytics.called(window.__adroll.record_user, {
+            adroll_segments: '123',
+            path: '/test/',
+            referrer: '',
+            title: 'integrations tests',
+            search: '',
+            name: 'Name',
+            category: 'Category',
+            url: 'http://localhost:34448/test/'
+          });
+        });
+
+        it('should not track unmapped page calls', function(){
+          analytics.page({ url: 'http://localhost:34448/test/' });
+          analytics.didNotCall(window.__adroll.record_user);
         });
       });
     });
@@ -168,22 +205,31 @@ describe('AdRoll', function(){
         analytics.stub(window.__adroll, 'record_user');
       });
 
-      it('should snake case event name', function(){
+      it('v1: should snake case unmapped event name', function(){
+        adroll.options.v1 = true;
         analytics.track('Event A');
         analytics.called(window.__adroll.record_user, {
           adroll_segments: 'event_a'
         });
       });
 
+      it('V2: should omit unmapped events', function(){
+        adroll.options.v1 = false;
+        analytics.track('Event A');
+        analytics.didNotCall(window.__adroll.record_user);
+      });
+
       describe('event not in events', function(){
-        it('should send events with only adroll_segments', function(){
+        it('v1: should send events with only adroll_segments', function(){
+          adroll.options.v1 = true;
           analytics.track('event', {});
           analytics.called(window.__adroll.record_user, {
             adroll_segments: 'event'
           });
         });
 
-        it('should send events with revenue and order id', function(){
+        it('v1: should send events with revenue and order id', function(){
+          adroll.options.v1 = true;
           analytics.track('event', { revenue: 3.99, order_id: 1 });
           analytics.called(window.__adroll.record_user, {
             adroll_segments: 'event',
@@ -192,7 +238,8 @@ describe('AdRoll', function(){
           });
         });
 
-        it('should pass user id in', function(){
+        it('v1: should pass user id in', function(){
+          adroll.options.v1 = true;
           analytics.user().identify('id');
           analytics.track('event', { revenue: 3.99 });
           analytics.called(window.__adroll.record_user, {
@@ -201,17 +248,23 @@ describe('AdRoll', function(){
             user_id: 'id'
           });
         });
+
+        it('V2: should not send event', function(){
+          adroll.options.v1 = false;
+          analytics.track('event', {});
+          analytics.didNotCall(window.__adroll.record_user);
+        });
       });
 
       describe('event in events', function(){
         beforeEach(function(){
-          adroll.options.events = { event: 'segment' };
+          adroll.options.events = { event: 'segmentId' };
         });
 
         it('should pass in revenue and order id', function(){
           analytics.track('event', { total: 1.99, orderId: 1 });
           analytics.called(window.__adroll.record_user, {
-            adroll_segments: 'segment',
+            adroll_segments: 'segmentId',
             adroll_conversion_value_in_dollars: 1.99,
             order_id: 1
           });
@@ -220,7 +273,7 @@ describe('AdRoll', function(){
         it('should pass .revenue as conversion value', function(){
           analytics.track('event', { revenue: 2.99 });
           analytics.called(window.__adroll.record_user, {
-            adroll_segments: 'segment',
+            adroll_segments: 'segmentId',
             adroll_conversion_value_in_dollars: 2.99,
           });
         });
@@ -229,7 +282,7 @@ describe('AdRoll', function(){
           analytics.user().identify('id');
           analytics.track('event', { revenue: 3.99 });
           analytics.called(window.__adroll.record_user, {
-            adroll_segments: 'segment',
+            adroll_segments: 'segmentId',
             adroll_conversion_value_in_dollars: 3.99,
             user_id: 'id'
           });
@@ -238,31 +291,14 @@ describe('AdRoll', function(){
         it('should pass custom data like product id and sku', function(){
           analytics.track('event', { revenue: 2.99, id: '12345', sku: '43434-21', other: '1234' });
           analytics.called(window.__adroll.record_user, {
-            adroll_segments: 'segment',
+            adroll_segments: 'segmentId',
             adroll_conversion_value_in_dollars: 2.99,
             product_id: '12345',
             sku: '43434-21',
-            adroll_custom_data: { other: '1234' },
+            other: '1234',
             order_id: '12345'
           });
         });
-
-        it('should support array events', function(){
-          adroll.options.events = [{ key: 'event', value: 'pixel' }];
-          analytics.track('event', { total: 2.99, orderId: 2 });
-          analytics.called(window.__adroll.record_user, {
-            adroll_segments: 'pixel',
-            adroll_conversion_value_in_dollars: 2.99,
-            order_id: 2
-          });
-        });
-
-        it('should track multiple events', function(){
-          adroll.options.events = [{ key: 'event', value: 'one' }];
-          adroll.options.events.push({ key: 'event', value: 'two' });
-          analytics.track('event', { total: 2.99, orderId: 2 });
-          analytics.calledTwice(window.__adroll.record_user);
-        })
       });
     });
   });


### PR DESCRIPTION
Three fixes rolled into one PR:

**1) Support for sending email (closes #610)**
Original patch submitted by @leohklee. Thanks! :smile: 

**2) Fixes adroll custom data behavior (closes #588)**
This was a great catch by @chiplay. As he explained in #588, the `__adroll.record_user` method parses out top level fields and "custom data" itself. The docs that show setting the `adroll_custom_data` object are referring to a global object on the window, not a sub-object that gets passed into that method. Not sure how we missed this :/

![](https://cloudup.com/c-LJgdiHQ30+)

**3) Deprecates sending segments by name** ([Related Ticket](https://segment.zendesk.com/agent/tickets/28111))
As of April it's required to use a [segmentId](https://help.adroll.com/hc/en-us/articles/203637220-Advanced-Non-URL-Segmentation-Strategies#content-anchor) instead of a segment name, so the strategy to deal with this in a non-breaking manner is to put new users on a "v2" and leave old users on "v1" (`options.legacy == true`).

Only distinction between v1 and v2 is that v1 would send unmapped events with `adroll_segments` set to the snake_cased event name, which will no longer be accepted for any new segments. The reason I'd argue we can't just remove support for unmapped events is because adroll still supports the `segment_name` approach for any segments created prior to March, and we have lots of existing customers relying on that who never needed to specifically map the events before unless they wanted to map multiple events to a given segment like the example here:

![](https://cloudup.com/cQyZgOi_pRV+) 

For _mapped events_, the behavior is the exact same, we'll just need to update documentation that new users need to map to the segment_id instead of the snaked name prepended with a `+`.

Obviously, status is **DO NOT MERGE**  until we update metadata for the hidden `legacy` field and the migration is run, and pending @amillet89's agreement that the `legacy` route is the correct one :)
