### PR TITLE
Use 'gv' property for bing ads revenue

### DIFF
--- a/lib/bing-ads/index.js
+++ b/lib/bing-ads/index.js
@@ -92,7 +92,7 @@ Bing.prototype.track = function(track){
   };
 
   if (track.category()) event.ec = track.category();
-  if (track.revenue()) event.ev = track.revenue();
+  if (track.revenue()) event.gv = track.revenue();
 
   window.uetq.push(event);
 };

--- a/lib/bing-ads/test.js
+++ b/lib/bing-ads/test.js
@@ -67,7 +67,7 @@ describe('Bing Ads', function(){
           ea: 'track',
           el: 'play',
           ec: 'fun',
-          ev: 90
+          gv: 90
         });
       });
     });


### PR DESCRIPTION
According to the Bing docs:

https://msdn.microsoft.com/en-us/library/bing-ads-universal-event-tracking-uet-tags-analytics-scripts.aspx

when sending tracking for revenue (e.g. 'Completed Order'), the goal value (`gv`) should be used, not the `ev` value. Furthermore, the `ev` value can only be an integer value which is causing a Javascript error.

For example:

```
var t = {ea: 'track', el: 'Completed Order', ev: 100.50}
window.uetq.push(t);
```

fails with:

`Uncaught ev should be an integer`

However, when using `gv`:

```
var t = {ea: 'track', el: 'Completed Order', gv: 100.50}
window.uetq.push(t);
```

it works correctly.
