### PR TITLE
GoSquared now auto-tags visitors on the back-end

### DIFF
--- a/lib/gosquared/index.js
+++ b/lib/gosquared/index.js
@@ -130,12 +130,6 @@ GoSquared.prototype.identify = function(identify){
   } else {
     push('properties', props);
   }
-
-  var email = identify.email();
-  var username = identify.username();
-
-  var name = email || username || id;
-  if (name) push('set', 'visitorName', name);
 };
 
 /**

--- a/lib/gosquared/test.js
+++ b/lib/gosquared/test.js
@@ -223,19 +223,6 @@ describe('GoSquared', function(){
           }
         });
       });
-
-      it('should prefer an email for visitor name', function(){
-        analytics.identify('id', {
-          email: 'email@example.com',
-          username: 'username'
-        });
-        analytics.called(window._gs, 'set', 'visitorName', 'email@example.com');
-      });
-
-      it('should also prefer a username for visitor name', function(){
-        analytics.identify('id', { username: 'username' });
-        analytics.called(window._gs, 'set', 'visitorName', 'username');
-      });
     });
 
     describe('#track', function(){


### PR DESCRIPTION
We no longer need the `tag` call as GoSquared will automatically do this behind-the-scenes when we get the `identify` request.
