### PR TITLE
Optimizely: roots fix

### DIFF
--- a/lib/optimizely/index.js
+++ b/lib/optimizely/index.js
@@ -110,11 +110,12 @@ Optimizely.prototype.roots = function(){
   if (!data) return;
   var allExperiments = data.experiments;
   if (!data || !data.state || !allExperiments) return;
-  var variationNamesMap = data.state.variationNamesMap;
-  var variationIdsMap = data.state.variationIdsMap;
-  var activeExperimentIds = data.state.activeExperiments;
-  var activeExperiments = getExperiments(activeExperimentIds, variationNamesMap,
-    variationIdsMap, allExperiments);
+  var activeExperiments = getExperiments({
+    variationNamesMap: data.state.variationNamesMap,
+    variationIdsMap: data.state.variationIdsMap,
+    activeExperimentIds: data.state.activeExperiments,
+    allExperiments: allExperiments
+  });
   var self = this;
 
   each(activeExperiments, function(props){
@@ -157,22 +158,20 @@ Optimizely.prototype.replay = function(){
  * Retrieves active experiments.
  *
  * @api private
- * @param {Object} state
- * @param {Object} allExperiments
+ * @param {Object} options
  */
 
-// FIXME: This should accept an options object rather than all these parameters
-function getExperiments(activeExperimentIds, variationNamesMap, variationIdsMap, allExperiments){
+function getExperiments(options){
   return foldl(function(results, experimentId){
-    var experiment = allExperiments[experimentId];
+    var experiment = options.allExperiments[experimentId];
     if (experiment) {
       results.push({
-        variationName: variationNamesMap[experimentId],
-        variationId: variationIdsMap[experimentId],
+        variationName: options.variationNamesMap[experimentId],
+        variationId: options.variationIdsMap[experimentId][0],
         experimentId: experimentId,
         experimentName: experiment.name
       });
     }
     return results;
-  }, [], activeExperimentIds);
+  }, [], options.activeExperimentIds);
 }

--- a/lib/optimizely/test.js
+++ b/lib/optimizely/test.js
@@ -22,7 +22,7 @@ describe('Optimizely', function(){
       state: {
         activeExperiments: [0],
         variationNamesMap: { 0: 'Variation1' },
-        variationIdsMap: { 0: 123 }
+        variationIdsMap: { 0: [123] }
       }
     };
   });


### PR DESCRIPTION
Roots fix: Optimizely's `window.optimizely.variationIdsMap` is a dictionary where the key is the experimentId and the value is the variationId. For some reason this value is wrapped in an Array, even though there is no indication that there would be more than one value, as seen here: https://cloudup.com/c8RGoyU1Onh. This fix pulls that variationId out of that array.

Style fix: passed an object instead of 4 params to `getExperiments` method
